### PR TITLE
Correct double naming

### DIFF
--- a/Support/Templates/GLD_Harmonization_Template.do
+++ b/Support/Templates/GLD_Harmonization_Template.do
@@ -865,8 +865,8 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen double wage_no_compen_year_2 = 
-	label var wage_no_compen_year_2 "Last wage payment secondary job 7 day recall"
+	gen double wage_no_compen_2 = 
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 


### PR DESCRIPTION
Line 868, 869 had wage_no_compen_year_2 instead of wage_no_compen_2 @alexandraqn  I think this addresses an earlier issue you raised.