### PR TITLE
#Section 4.1 Static Checks GLD

### DIFF
--- a/Support/Q Checks/Helper Programs/GLD Static Q-Checks.do
+++ b/Support/Q Checks/Helper Programs/GLD Static Q-Checks.do
@@ -271,6 +271,7 @@ foreach three_vars of global subnat_hierarchy {
 cap confirm variable hsize
 if _rc == 0 { // if var exists since if not captured in 1.1
 	bysort hhid: gen hh_size_verify = _N
+	replace hh_size_verify=. if hsize==. /* I think this fixes the issue with red flag in the check output*/
 	qui : count if hh_size_verify != hsize
 	if `r(N)' >0 { // there are cases when it differs
 		local hh_size_error_ratio = `r(N)' / $overall_count


### PR DESCRIPTION
Hi Mario, I think that introducing this line will fix a recurrent issue from the checks. In the output I used to get for all my datasets issues with the hhsize and number of obs per household. After a quick br, I noticed that stata generated integers(7, 4, 5, 3) for the variable hh_size_verify even though hsize had missing values for the hhid. I fixed this so that the count now compares equivalent variables. I am happy to discuss this further if you wish.