### PR TITLE
Convert 2016 isco codes to ISCO-08

### DIFF
--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1,4 +1,4 @@
-isco88/*%%=============================================================================================
+/*%%=============================================================================================
 	0: GLD Harmonization Preamble
 ==============================================================================================%%*/
 
@@ -1064,15 +1064,13 @@ foreach v of local ed_var {
 		// merge sub-module with isco key
 		/* Here, we will substring the key and matchvar to match only at two digits. */
 
-		gen isco88 	= `matchvar'
-		gen isco88_2dig = substr(isco88,1,2)
-
-
+		gen isco88_2dig = substr(`matchvar',1,2)
 
 		tostring 	isco88_2dig ///
-					, format(`"%04.0f"') replace
+					, format(`"%02.0f"') replace
 
-		replace 	isco88_2dig = "" 	if wave != "Q1" 	// only first second wave
+		gen 			isco08_2dig = isco88_2dig 	if wave != "Q1" 	// for waves 2-4
+		replace 	isco88_2dig = "" 						if wave != "Q1" 	// will merge only first wave
 
 		merge 		m:1 ///
 					isco88_2dig ///
@@ -1083,10 +1081,10 @@ foreach v of local ed_var {
 
 		tab 		isic_merge_`n' 		if `matchvar' != .
 
-		drop 		isco88 				// no longer needed, maintained in matchvar
 
+		gen 		occup_isco = isco08_2dig 			// catches values converted in Q1 merge
+		replace occup_isco = isco08_2dig			if wave != "Q1"	// replace rest of waves with values
 
-		gen 		occup_isco = isco08_`n'
 		label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1089,8 +1089,6 @@ foreach v of local ed_var {
 
 		label var 	occup_isco "ISIC code of primary job 7 day recall"
 
-		pause on 
-		pause
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1057,17 +1057,19 @@ foreach v of local ed_var {
 				, generate(occup_orig_str) ///			// gen a variable with this prefix
 				force //
 
-
+			replace 	occup_orig_str = "" if occup_orig_str == "."
 		}
 
 
 		// merge sub-module with isco key
 		/* Here, we will substring the key and matchvar to match only at two digits. */
 
-		gen isco88_2dig = substr(`matchvar',1,2)
+		gen isco88_2dig = substr(occup_orig_str,1,2)
 
 		tostring 	isco88_2dig ///
 					, format(`"%02.0f"') replace
+					
+		replace 	isco88_2dig = "" if isco88_2dig == "."		// replace missing with numeric missing.
 
 		gen 			isco08_2dig = isco88_2dig 	if wave != "Q1" 	// for waves 2-4
 		replace 	isco88_2dig = "" 						if wave != "Q1" 	// will merge only first wave
@@ -1078,16 +1080,17 @@ foreach v of local ed_var {
 					, generate(isco_merge_`n') ///
 					keep(master match) // "left join"; remove obs that don't match from using
 
-
-		tab 		isic_merge_`n' 		if `matchvar' != .
-
-
+		tab 		isco_merge_`n'
+		tab         isco_merge_1 if occup_orig_str  != "" & wave == "Q1"
+					* all non-matched isco-88 don't exist in key
+		
 		gen 		occup_isco = isco08_2dig 			// catches values converted in Q1 merge
-		replace occup_isco = isco08_2dig			if wave != "Q1"	// replace rest of waves with values
+		replace 	occup_isco = isco08_2dig			if wave != "Q1"	// replace rest of waves with values
 
 		label var 	occup_isco "ISIC code of primary job 7 day recall"
 
-
+		pause on 
+		pause
 
 *</_occup_isco_>
 

--- a/Support/Global/international_codes.R
+++ b/Support/Global/international_codes.R
@@ -409,8 +409,25 @@ match_isco88_08_list <- corresp(df = isco88_08_clean,
                                 check_matches = F)
   
 
-match_isco88_08_table <- match_isco88_08_list[[1]]
+match_isco88_08_table <- match_isco88_08_list[[1]] 
+
+
+# create a 2-digit match table for isco88-to-08
+isco88_08_2dig <- isco88_08_clean %>%
+  mutate(isco08_2dig = stringr::str_sub(isco08, 1,2),
+         isco88_2dig = stringr::str_sub(isco88, 1,2)) %>%
+  #distinct(across(contains("2dig")), .keep_all = TRUE) %>%
+  select(contains("2dig"), "title08")
+
+match_isco88_08_2dig_list <- corresp(df = isco88_08_2dig,
+                                     country_code = isco88_2dig, 
+                                     international_code = isco08_2dig,
+                                     pad_vars = NULL,
+                                     check_matches = F)
   
+match_isco88_08_2dig_table <- match_isco88_08_2dig_list[[1]]  
+
+
 
 # save data ----
 if (TRUE) {
@@ -424,6 +441,7 @@ save(isic94_codes_raw, isic94_codes, isic94_leftover, isic94_clean, psic94_path,
      match_isic09_list, match_isic09_table, 
      match_isco12_list, match_isco12_table,
      match_isco88_08_list, match_isco88_08_table,
+     match_isco88_08_2dig_list, match_isco88_08_2dig_table,
      file = file.path(PHL, "PHL_data/international_codes.Rdata") )
 
 
@@ -463,6 +481,15 @@ haven::write_dta(match_isco88_08_table,
                                            "_v01_M/Data/Stata/PHL_PSOC_ISCO_88_08_key.dta")),
                    version = 14)
 }  
+  
+for (i in seq(from=2016,to=2016)) {
+  haven::write_dta(match_isco88_08_2dig_table,
+                   path = file.path(PHL, 
+                                    paste0("PHL_",as.character(i),"_LFS"), 
+                                    paste0("PHL_",as.character(i),"_LFS",
+                                           "_v01_M/Data/Stata/PHL_PSOC_ISCO_88_08_key_2digits.dta")),
+                   version = 14)
+}  
 
 
 haven::write_dta(match_isic94_table,
@@ -480,4 +507,8 @@ haven::write_dta(match_isco12_table,
 
 haven::write_dta(match_isco88_08_table,
                  path = file.path(PHL, "PHL_data/GLD/PHL_PSOC_ISCO_88_08_key.dta"),
+                 version = 14)
+
+haven::write_dta(match_isco88_08_2dig_table,
+                 path = file.path(PHL, "PHL_data/GLD/PHL_PSOC_ISCO_88_08_key_2digits.dta"),
                  version = 14)

--- a/Support/Global/international_codes.R
+++ b/Support/Global/international_codes.R
@@ -410,6 +410,7 @@ match_isco88_08_list <- corresp(df = isco88_08_clean,
   
 
 match_isco88_08_table <- match_isco88_08_list[[1]]
+  
 
 # save data ----
 if (TRUE) {
@@ -455,7 +456,7 @@ for (i in seq(from=2016,to=2019)) {
 }
 
 for (i in seq(from=2016,to=2016)) {
-haven::write_dta(match_isco12_table,
+haven::write_dta(match_isco88_08_table,
                  path = file.path(PHL, 
                                   paste0("PHL_",as.character(i),"_LFS"), 
                                     paste0("PHL_",as.character(i),"_LFS",


### PR DESCRIPTION
This PR resolves a few issues but requires comments. It addresses #123 and essentially supersedes the need to address the encoding issues in #127. However, the raw data for all rounds in 2016 is two digits, not four. Usually, for `occup_isco` the data would be left as missing in this case. However, I've decided that it may be worth converting the 2-digit data to the same ISCO schema in some way since this is the only year that spans two schemas. If `occup_orig` is simply left as-is, and `occup` as a categorical variable is left unaffected by the difference in ISCO schemas, then the user may be reasonably misled into thinking that `occup_orig` is harmonized within-year; but in this case it's not. 

What I've done, for now, is I've simply converted the 2-digit data to ISCO-08 following the same processes as 4-digit data and coded this data in `occup_isco`, recognizing that this variable is typically reserved for four-digit data. I'm open to other ideas, but I do think some sort of converted variable is worth considering given the circumstances for 2016. I want the user to have access to harmonized ISCO data somehow, even if the data are only 2-digits in the end. 

Linking also the PR where I created the conversion table in R #137 