### PR TITLE
Incorporate ISIC and ISCO 2-digit data

### DIFF
--- a/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1010,9 +1010,6 @@ foreach v of local ed_var {
 	// replace one code that I know doesn't match
 	rename 		isic3_1_2dig	isic3_1_2dig_`n'
 
-	tab 		isic_merge_`n' 		if `matchvar' != .
-
-
 	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
@@ -1087,8 +1084,7 @@ foreach v of local ed_var {
 
 
 	rename 		isco88_sub_major	isco88_sub_major_`n'
-	tab 		isic_merge_`n' 		if `matchvar' != .
-
+	
 	drop 		psoc92 				// no longer needed, maintained in matchvar
 	gen 		occup_isco = isco88_sub_major_`n'
 	label var 	occup_isco "ISIC code of primary job 7 day recall"

--- a/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1084,7 +1084,7 @@ foreach v of local ed_var {
 
 
 	rename 		isco88_sub_major	isco88_sub_major_`n'
-	
+
 	drop 		psoc92 				// no longer needed, maintained in matchvar
 	gen 		occup_isco = isco88_sub_major_`n'
 	label var 	occup_isco "ISIC code of primary job 7 day recall"

--- a/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
@@ -94,7 +94,7 @@ set mem 800m
 	local round4 `"`stata'\LFS OCT1997.dta"'
 
 	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"' // to be created
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 

--- a/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_1997_LFS/PHL_1997_LFS_v01_M_v01_A_GLD/Programs/PHL_1997_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL1997.dta"'
 	local round4 `"`stata'\LFS OCT1997.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"' // to be created
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -979,9 +979,44 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*1997 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	qkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	tab 		isic_merge_`n' 		if `matchvar' != .
+
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1023,11 +1058,40 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+	tab 		isic_merge_`n' 		if `matchvar' != .
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_1998_LFS/PHL_1998_LFS_v01_M_v01_A_GLD/Programs/PHL_1998_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_1998_LFS/PHL_1998_LFS_v01_M_v01_A_GLD/Programs/PHL_1998_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL1998.dta"'
 	local round4 `"`stata'\LFS OCT1998.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"' // to be created
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -971,9 +971,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*1998 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	qkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1015,11 +1047,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_1999_LFS/PHL_1999_LFS_v01_M_v01_A_GLD/Programs/PHL_1999_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_1999_LFS/PHL_1999_LFS_v01_M_v01_A_GLD/Programs/PHL_1999_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL1999.dta"'
 	local round4 `"`stata'\LFS OCT1999.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"' // to be created
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -979,9 +979,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*1999 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	qkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1023,11 +1055,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2000_LFS/PHL_2000_LFS_v01_M_v01_A_GLD/Programs/PHL_2000_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2000_LFS/PHL_2000_LFS_v01_M_v01_A_GLD/Programs/PHL_2000_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2000.dta"'
 	local round4 `"`stata'\LFS OCT2000.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -979,9 +979,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2000 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	qkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1023,11 +1055,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2001_LFS/PHL_2001_LFS_v01_M_v01_A_GLD/Programs/PHL_2001_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2001_LFS/PHL_2001_LFS_v01_M_v01_A_GLD/Programs/PHL_2001_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2001.dta"'
 	local round4 `"`stata'\LFS OCT2001.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1000,9 +1000,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2001 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c16_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1050,11 +1082,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c14_procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1230,8 +1290,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	c29_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1270,8 +1363,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	c27_otocc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2002_LFS/PHL_2002_LFS_v01_M_v01_A_GLD/Programs/PHL_2002_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2002_LFS/PHL_2002_LFS_v01_M_v01_A_GLD/Programs/PHL_2002_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2002.dta"'
 	local round4 `"`stata'\LFS OCT2002.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -978,9 +978,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2002 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c16a_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1028,11 +1060,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c14a_procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1208,8 +1268,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	c30a_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1248,8 +1341,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	c28a_otocc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2003_LFS/PHL_2003_LFS_v01_M_v01_A_GLD/Programs/PHL_2003_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2003_LFS/PHL_2003_LFS_v01_M_v01_A_GLD/Programs/PHL_2003_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1141,7 +1141,7 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	loc matchvar   	c16_pkb
+	loc matchvar   	c16a_pkb
 	loc n 			1
 
 	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric

--- a/GLD/PHL/PHL_2003_LFS/PHL_2003_LFS_v01_M_v01_A_GLD/Programs/PHL_2003_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2003_LFS/PHL_2003_LFS_v01_M_v01_A_GLD/Programs/PHL_2003_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2003.dta"'
 	local round4 `"`stata'\LFS OCT2003.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1141,9 +1141,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2003 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c16_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1191,11 +1223,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c14a_procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1371,8 +1431,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	c30a_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1411,8 +1504,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	c28a_otocc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2004_LFS/PHL_2004_LFS_v01_M_v01_A_GLD/Programs/PHL_2004_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2004_LFS/PHL_2004_LFS_v01_M_v01_A_GLD/Programs/PHL_2004_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2004.dta"'
 	local round4 `"`stata'\LFS OCT2004.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1109,9 +1109,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2004 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1159,11 +1191,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1339,8 +1399,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1379,8 +1472,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2005_LFS/PHL_2005_LFS_v01_M_v01_A_GLD/Programs/PHL_2005_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2005_LFS/PHL_2005_LFS_v01_M_v01_A_GLD/Programs/PHL_2005_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2005.dta"'
 	local round4 `"`stata'\LFS OCT2005.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -983,9 +983,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2005 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1033,11 +1065,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1213,8 +1273,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1253,8 +1346,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2006_LFS/PHL_2006_LFS_v01_M_v01_A_GLD/Programs/PHL_2006_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2006_LFS/PHL_2006_LFS_v01_M_v01_A_GLD/Programs/PHL_2006_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2006.dta"'
 	local round4 `"`stata'\LFS OCT2006.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1141,9 +1141,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2006 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c17f2_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1191,11 +1223,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2008_LFS/PHL_2008_LFS_v01_M_v01_A_GLD/Programs/PHL_2008_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2008_LFS/PHL_2008_LFS_v01_M_v01_A_GLD/Programs/PHL_2008_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2008.dta"'
 	local round4 `"`stata'\LFS OCT2008.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -979,9 +979,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2008 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1029,11 +1061,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1211,8 +1271,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1250,8 +1343,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2009_LFS/PHL_2009_LFS_v01_M_v01_A_GLD/Programs/PHL_2009_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2009_LFS/PHL_2009_LFS_v01_M_v01_A_GLD/Programs/PHL_2009_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2009.dta"'
 	local round4 `"`stata'\LFS OCT2009.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -982,9 +982,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2009 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1032,11 +1064,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1214,8 +1274,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1253,8 +1346,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2010_LFS/PHL_2010_LFS_v01_M_v01_A_GLD/Programs/PHL_2010_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2010_LFS/PHL_2010_LFS_v01_M_v01_A_GLD/Programs/PHL_2010_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2010.dta"'
 	local round4 `"`stata'\LFS OCT2010.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -984,9 +984,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2010 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1034,11 +1066,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1216,8 +1276,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1255,8 +1348,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2011_LFS/PHL_2011_LFS_v01_M_v01_A_GLD/Programs/PHL_2011_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2011_LFS/PHL_2011_LFS_v01_M_v01_A_GLD/Programs/PHL_2011_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2011.dta"'
 	local round4 `"`stata'\LFS OCT2011.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -984,9 +984,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	/*2011 only has 2-digit data for industry, so cannot be constructed*/
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
+
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 
 
@@ -1034,11 +1066,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* incoming data only has 2-digit, so cannot be mapped to isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 
@@ -1216,8 +1276,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1255,8 +1348,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,7 +93,7 @@ set mem 800m
 	local round3 `"`stata'\LFSjul12.dta"'
 	local round4 `"`stata'\LFS OCT2012.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'  // 4 digits
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'  // 4 digits
 	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'  // 2 digits
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'

--- a/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1105,7 +1105,7 @@ foreach v of local ed_var {
 	// merge sub-module with isco key
 
 	gen psoc92_4dig = `matchvar'
-	tostring 	psoc92 ///
+	tostring 	psoc92_4dig ///
 				, format(`"%04.0f"') replace
 
 	gen psoc92  = substr(psoc92_4dig, 1,2)
@@ -1453,7 +1453,7 @@ foreach v of local ed_var {
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = c32_obasis
+	gen byte 		unitwage_2 = j06_obasis
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly

--- a/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1276,9 +1276,6 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2012 has no secondary job information.
-*/
 
 {
 *<_empstat_2_>
@@ -1393,9 +1390,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-* even though the original data hve 4 digits, there is no conversion table for PSOC to ISCO
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otocc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 
@@ -1426,7 +1453,7 @@ foreach v of local ed_var {
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obasis
+	gen byte 		unitwage_2 = c32_obasis
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly

--- a/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v01_A_GLD/Programs/PHL_2012_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFSjul12.dta"'
 	local round4 `"`stata'\LFS OCT2012.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'  // 4 digits
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'  // 2 digits
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1086,11 +1086,42 @@ foreach v of local ed_var {
 
 *<_occup_isco_>
 * in 2012, raw variable is numeric, 4-digits, but since there is no provided PSOC to ISCO
-* conversion, there is no occup_isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+* conversion, at 4 digits, substring to 2 and match at 2
+	loc matchvar   	c16_procc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92_4dig = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%04.0f"') replace
+
+	gen psoc92  = substr(psoc92_4dig, 1,2)
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2013_LFS/PHL_2013_LFS_v01_M_v01_A_GLD/Programs/PHL_2013_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2013_LFS/PHL_2013_LFS_v01_M_v01_A_GLD/Programs/PHL_2013_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1104,7 +1104,7 @@ foreach v of local ed_var {
 	// merge sub-module with isco key
 
 	gen psoc92_4dig = `matchvar'
-	tostring 	psoc92 ///
+	tostring 	psoc92_4dig ///
 				, format(`"%04.0f"') replace
 
 	gen psoc92  = substr(psoc92_4dig, 1,2)
@@ -1451,7 +1451,7 @@ foreach v of local ed_var {
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = c32_obasis
+	gen byte 		unitwage_2 = j06_obasis
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly

--- a/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v01_A_GLD/Programs/PHL_2014_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v01_A_GLD/Programs/PHL_2014_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1256,9 +1256,7 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2014 has no secondary job information.
-*/
+
 
 {
 *<_empstat_2_>
@@ -1282,11 +1280,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
-	* no 4-digit data, so cannot complete.
-	gen 			industrycat_isic_2 = .
-	label var 		industrycat_isic_2 "ISIC code of primary job 7 day recall"
+	loc matchvar   	j03_okb
+	loc n 			2
+
+	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig_2	///						// make the numeric vars strings
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				force //
+		}
 
 
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
@@ -1328,9 +1356,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_2_>
-* even though the original data hve 4 digits, there is no conversion table for PSOC to ISCO
-	gen 			occup_isco_2 = ""
-	label var 		occup_isco_2 "ISCO code of secondary job 7 day recall"
+	loc matchvar   	j02_otoc
+	loc n 			2
+
+	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig_2	///						// make the numeric vars strings
+				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco_2 = isco88_sub_major_`n'
+	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v01_A_GLD/Programs/PHL_2014_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v01_A_GLD/Programs/PHL_2014_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1014,9 +1014,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
@@ -1309,9 +1309,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic_2 = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"

--- a/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v01_A_GLD/Programs/PHL_2014_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v01_A_GLD/Programs/PHL_2014_LFS_v01_M_v01_A_GLD_ALL.do
@@ -13,7 +13,7 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2014 </_Survey Year_>
+<_Survey Year_>					2001 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
 <_Data collection from_>		[01/2014] </_Data collection from_>
 <_Data collection to_>			[10/2014] </_Data collection to_>
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2014.dta"'
 	local round4 `"`stata'\LFS OCT2014.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -317,7 +317,7 @@ replace int_month = 10 	if round == 4
 	label 		var weight "Household sampling weight"
 
 	/*there is one household with an odd household ID and no weight (total 1 observation). Will drop*/
-	drop 		if weight == . 
+	drop 		if weight == .
 	assert 		r(N_drop) == 1  	// ensure only 1 obs was dropped
 *</_weight_>
 
@@ -985,10 +985,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	* 2014 data only has 2 digits for industry so no ISIC can be generated
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
 
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 	*</_industrycat_isic_>
 
 
@@ -1038,12 +1069,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* in 2014, raw variable is numeric, 4-digits, but since there is no provided PSOC to ISCO
-* conversion, there is no occup_isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2015_LFS/PHL_2015_LFS_v01_M_v01_A_GLD/Programs/PHL_2015_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2015_LFS/PHL_2015_LFS_v01_M_v01_A_GLD/Programs/PHL_2015_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1011,9 +1011,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
@@ -1306,9 +1306,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic_2 = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"

--- a/GLD/PHL/PHL_2015_LFS/PHL_2015_LFS_v01_M_v01_A_GLD/Programs/PHL_2015_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2015_LFS/PHL_2015_LFS_v01_M_v01_A_GLD/Programs/PHL_2015_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2015.dta"'
 	local round4 `"`stata'\LFS OCT2015.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'
-	local isco_key 	 `"`stata'\"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -982,10 +982,41 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	* 2015 data only has 2 digits for industry so no ISIC can be generated
-	gen 			industrycat_isic = .
-	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+	loc matchvar   	c18_pkb
+	loc n 			1
 
+	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc isicvar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 	*</_industrycat_isic_>
 
 
@@ -1035,12 +1066,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* in 2015, raw variable is numeric, 4-digits, but since there is no provided PSOC to ISCO
-* conversion, there is no occup_isco
-	gen 			occup_isco = ""
-	label 			var occup_isco "ISCO code of primary job 7 day recall"
-	replace 		occup_isco="" if lstatus!=1 		// restrict universe to employed only
-	replace 		occup_isco="" if age < minlaborage	// restrict universe to working age
+	loc matchvar   	c16_proc
+	loc n 			1
+
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
+	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1075,7 +1075,8 @@ foreach v of local ed_var {
 				, format(`"%02.0f"') replace
 
 	replace 	psic_2dig = "" 	if wave == "Q1" 	// don't match first wave
-
+	replace 	psic_2dig = "" 	if psic_2dig == "." 	// fix missing
+	
 	merge 		m:1 ///
 				psic_2dig ///
 				using `isco_key' ///
@@ -1084,7 +1085,7 @@ foreach v of local ed_var {
 
 	rename 		isco08_2dig	isco08_`n'			// rename converted isco var
 
-	tab 		isic_merge_`n' 		if `matchvar' != .
+	tab 		isco_merge_`n' 			if occup_orig_str != "" & wave != "Q1"
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1013,9 +1013,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
@@ -1359,9 +1359,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic_2 = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v01_A_GLD/Programs/PHL_2016_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1119,14 +1119,14 @@ foreach v of local ed_var {
 
 	// merge with isco92 key
 	merge 		m:1 ///
-				psic_2dig ///
+				psoc92 ///
 				using `isco_key92' ///
 				, generate(isco_merge92_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
 
 	// coalese 2 variables
-	egen 		occup_isco_`n' = rowfirst(isco08_2dig sub_major_isco08)
+	egen 		str2 occup_isco_`n' = rowfirst(isco08_2dig sub_major_isco08)
 
 	drop 		psoc92 			// no longer needed, maintained in matchvar
 
@@ -1440,19 +1440,18 @@ foreach v of local ed_var {
 
 	// merge with isco92 key
 	merge 		m:1 ///
-				psic_2dig ///
+				psoc92 ///
 				using `isco_key92' ///
 				, generate(isco_merge92_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
 
 	// coalese 2 variables
-	egen 		occup_isco_`n' = rowfirst(isco08_2dig sub_major_isco08)
+	egen 		str2 occup_isco_`n' = rowfirst(isco08_2dig sub_major_isco08)
 
 	drop 		psoc92 				// no longer needed, maintained in matchvar
 
-	gen 		occup_isco_2 = occup_isco_`n'
-	label var 	occup_isco_2 "ISIC code of secondary job 7 day recall"
+ label var 	occup_isco_2 "ISIC code of secondary job 7 day recall"
 *</_occup_isco_2_>
 
 

--- a/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v01_A_GLD/Programs/PHL_2017_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v01_A_GLD/Programs/PHL_2017_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1196,7 +1196,7 @@ foreach v of local ed_var {
 	rename 		isic4_2dig isic4_2dig_`n'
 
 	// coalesce 2 variables
-	egen str4 	industrycat_isic = rowfirst(isic4_`n' isic4_2dig)
+	egen str4 	industrycat_isic = rowfirst(isic4_`n' isic4_2dig_`n')
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 
@@ -1688,7 +1688,7 @@ foreach v of local ed_var {
 				keep(master match) /// "left join"; remove obs that don't match from using
 				keepusing(unit isco08)
 
-	rename 		isic4_2dig isic4_2dig_`n'
+	rename 		isco08 isco08_`n'
 
 
 	// merge with 2 digit key

--- a/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v01_A_GLD/Programs/PHL_2017_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v01_A_GLD/Programs/PHL_2017_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1346,7 +1346,7 @@ foreach v of local ed_var {
 	// coalesce 2 variables
 	egen str4	occup_isco = rowfirst(isco08_`n' isco08_2dig_`n')
 
-	drop 		psic_2dig unit				// no longer needed, maintained in matchvar
+	drop 		psic_2dig				// no longer needed, maintained in matchvar
 
 	label var 	occup_isco "ISIC code of primary job 7 day recall"
 

--- a/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v01_A_GLD/Programs/PHL_2017_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v01_A_GLD/Programs/PHL_2017_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1169,9 +1169,8 @@ foreach v of local ed_var {
 	tostring 	class ///
 				, format(`"%04.0f"') replace
 
-	replace 	class = "" 	if wave != "Q2" 	// only match second wave
-
-
+	replace 	class = "" if wave != "Q2"
+	
 	merge 		m:1 ///
 				class ///
 				using `isic_key' ///
@@ -1184,7 +1183,11 @@ foreach v of local ed_var {
 	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
 	// merge with 2 digit key
-	rename  	class psic_2dig // rename for second merge
+	gen 		psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+	
+	replace 	psic_2dig = "" if wave == "Q2" // merge only for q2
 
 	merge 		m:1 ///
 				psic_2dig ///
@@ -1198,7 +1201,7 @@ foreach v of local ed_var {
 	// coalesce 2 variables
 	egen str4 	industrycat_isic = rowfirst(isic4_`n' isic4_2dig_`n')
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	drop 		psic_2dig class 				// no longer needed, maintained in matchvar
 
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
 	*</_industrycat_isic_>
@@ -1307,9 +1310,9 @@ foreach v of local ed_var {
 	gen unit = `matchvar'
 	tostring 	unit ///
 				, format(`"%04.0f"') replace
-
-	replace 	unit = "" 	if wave != "Q2" 	// only match second wave
-
+	
+	replace 	unit = "" if wave != "Q2" // merge only for q2
+	
 	merge 		m:1 ///
 				unit ///
 				using `isco_key' ///
@@ -1322,7 +1325,14 @@ foreach v of local ed_var {
 	replace 	isco08_`n' = "6810" 	if `matchvar' == 6819
 
 	// merge with 2 digit key
-	rename 		unit psic_2dig
+	drop 		unit 
+	
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+	
+	replace 	psic_2dig = "" if wave == "Q2" // don't merge q2	
+				
 
 	merge 		m:1 ///
 				psic_2dig ///
@@ -1336,7 +1346,7 @@ foreach v of local ed_var {
 	// coalesce 2 variables
 	egen str4	occup_isco = rowfirst(isco08_`n' isco08_2dig_`n')
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	drop 		psic_2dig unit				// no longer needed, maintained in matchvar
 
 	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
@@ -1550,8 +1560,8 @@ foreach v of local ed_var {
 	gen class = `matchvar'
 	tostring 	class ///
 				, format(`"%04.0f"') replace
-
-	replace 	class = "" 	if wave != "Q2" 	// only match second wave
+				
+	replace 	class = "" if wave != "Q2" // only match second wave at 4 digits			
 
 	merge 		m:1 ///
 				class ///
@@ -1565,7 +1575,11 @@ foreach v of local ed_var {
 	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
 	// merge with 2 digit key
-	rename  	class psic_2dig // rename for second merge
+	gen 		psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+	
+	replace 	psic_2dig = "" if wave == "Q2" // merge only for q2
 
 	merge 		m:1 ///
 				psic_2dig ///
@@ -1678,8 +1692,8 @@ foreach v of local ed_var {
 	gen unit = `matchvar'
 	tostring 	unit ///
 				, format(`"%04.0f"') replace
-
-	replace 	unit = "" 	if wave != "Q2" 	// only match second wave
+				
+	replace 	unit = "" if wave != "Q2"
 
 	merge 		m:1 ///
 				unit ///
@@ -1692,7 +1706,11 @@ foreach v of local ed_var {
 
 
 	// merge with 2 digit key
-	rename 		unit psic_2dig
+	gen 		psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+	
+	replace 	psic_2dig = "" if wave == "Q2" // merge only for q2
 
 	merge 		m:1 ///
 				psic_2dig ///

--- a/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Programs/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Programs/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1028,9 +1028,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"

--- a/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Programs/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Programs/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1101,21 +1101,21 @@ foreach v of local ed_var {
 
 	// merge sub-module with isco key
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
 				, format(`"%02.0f"') replace
 
 	merge 		m:1 ///
-				psoc92 ///
+				psic_2dig ///
 				using `isco_key' ///
 				, generate(isco_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
 
-	rename 		isco88_sub_major	isco88_sub_major_`n'
+	rename 		isco08_2dig	isco08_2dig_`n'
 
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco = isco88_sub_major_`n'
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco08_2dig_`n'
 	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>

--- a/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Programs/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Programs/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2018.dta"'
 	local round4 `"`stata'\LFS OCT2018.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key.dta"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key_2dig.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1002,11 +1002,38 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	* data are only 2-digits, so cannot be matched to isic
+	loc matchvar   	pufc16_pkb
+	loc n 			1
 
-	gen 		industrycat_isic = .
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-
 	*</_industrycat_isic_>
 
 
@@ -1057,12 +1084,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* in 2018, raw variable is numeric, 2-digits, so isco conversion not possible
+	loc matchvar   	pufc14_procc
+	loc n 			1
 
-	gen occup_isco = ""
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
 	label var 	occup_isco "ISIC code of primary job 7 day recall"
-
-
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v01_A_GLD/Programs/PHL_2019_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v01_A_GLD/Programs/PHL_2019_LFS_v01_M_v01_A_GLD_ALL.do
@@ -93,8 +93,8 @@ set mem 800m
 	local round3 `"`stata'\LFS JUL2019.dta"'
 	local round4 `"`stata'\LFS OCT2019.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key.dta"' // to be created
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key_2dig.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
@@ -1004,11 +1004,38 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
-	* data are only 2-digits, so cannot be matched to isic
+	loc matchvar   	pufc16_pkb
+	loc n 			1
 
-	gen 		industrycat_isic = .
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if industry_orig is numeric)
+			tostring industry_orig	///						// make the numeric vars strings
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				force //
+		}
+
+
+	// merge sub-module with isic key
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key' ///
+				, generate(isic_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+				* the string variable in isic4 will is industrycat_isic
+
+	// replace one code that I know doesn't match
+	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+
+	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-
 	*</_industrycat_isic_>
 
 
@@ -1059,12 +1086,39 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-* in 2019, raw variable is numeric, 2-digits, so isco conversion not possible
+	loc matchvar   	pufc14_procc
+	loc n 			1
 
-	gen occup_isco = ""	// occup_isco already generated above in submodule
+	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
+	loc iscovar 	= r(varlist)						// store this in a local
+	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
+
+		if (`len' == 1) {
+															// run this if == 1 (ie, if occup_orig is numeric)
+			tostring occup_orig	///						// make the numeric vars strings
+				, generate(occup_orig_str) ///			// gen a variable with this prefix
+				force
+		}
+
+
+	// merge sub-module with isco key
+
+	gen psoc92 = `matchvar'
+	tostring 	psoc92 ///
+				, format(`"%02.0f"') replace
+
+	merge 		m:1 ///
+				psoc92 ///
+				using `isco_key' ///
+				, generate(isco_merge_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+
+	rename 		isco88_sub_major	isco88_sub_major_`n'
+
+	drop 		psoc92 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco88_sub_major_`n'
 	label var 	occup_isco "ISIC code of primary job 7 day recall"
-
-
 
 *</_occup_isco_>
 

--- a/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v01_A_GLD/Programs/PHL_2019_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v01_A_GLD/Programs/PHL_2019_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1103,21 +1103,21 @@ foreach v of local ed_var {
 
 	// merge sub-module with isco key
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
 				, format(`"%02.0f"') replace
 
 	merge 		m:1 ///
-				psoc92 ///
+				psic_2dig ///
 				using `isco_key' ///
 				, generate(isco_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
 
-	rename 		isco88_sub_major	isco88_sub_major_`n'
+	rename 		isco08_2dig	isco08_2dig_`n'
 
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco = isco88_sub_major_`n'
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco08_2dig_`n'
 	label var 	occup_isco "ISIC code of primary job 7 day recall"
 
 *</_occup_isco_>

--- a/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v01_A_GLD/Programs/PHL_2019_LFS_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v01_A_GLD/Programs/PHL_2019_LFS_v01_M_v01_A_GLD_ALL.do
@@ -1030,9 +1030,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig	isic3_1_2dig_`n'
+	rename 		isic4_2dig	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"

--- a/Support/Country Survey Details/PHL/LFS/Rmd/Industry_Occupation_Codes.Rmd
+++ b/Support/Country Survey Details/PHL/LFS/Rmd/Industry_Occupation_Codes.Rmd
@@ -152,6 +152,22 @@ conditionally based on the round: January will receive one coding based
 on the 1992 PSOC and the rest of the rounds will be coded based on the
 2012 PSOC.
 
+##### For the occup_isco variable 
+
+Normally, a 2-digit conversion would be provided like this:
+
+1.  convert each PSOC schema to the ISCO equivalent
+
+    > (Wave1)	 1992 PSOC -\> 1988 ISCO
+    >
+    > (Wave2-4) 2012 ISCO -\> 2008 ISCO
+
+2.  Conversion 2: convert all ISCO revisions to ISCO 2008
+
+However, wave1 conversion cannot be done because we do not have a
+PSOC-\> ISCO conversion table.Therefore, the data for wave 1 will be
+left as missing.
+
 ## New Features in GLD Database
 
 The harmonizers working with GLD have made a great effort to reconcile

--- a/Support/Country Survey Details/PHL/LFS/Rmd/Industry_Occupation_Codes.Rmd
+++ b/Support/Country Survey Details/PHL/LFS/Rmd/Industry_Occupation_Codes.Rmd
@@ -152,13 +152,13 @@ conditionally based on the round: January will receive one coding based
 on the 1992 PSOC and the rest of the rounds will be coded based on the
 2012 PSOC.
 
-##### For the occup_isco variable 
+##### For the occup_isco variable
 
 Normally, a 2-digit conversion would be provided like this:
 
 1.  convert each PSOC schema to the ISCO equivalent
 
-    > (Wave1)	 1992 PSOC -\> 1988 ISCO
+    > (Wave1) 1992 PSOC -\> 1988 ISCO
     >
     > (Wave2-4) 2012 ISCO -\> 2008 ISCO
 

--- a/Support/Global/international_codes.R
+++ b/Support/Global/international_codes.R
@@ -530,6 +530,22 @@ match_isco12_2dig_table <- match_isco12_2dig_list[[1]]
 
 
 
+# create a 2-digit match table for isco88-to-08
+isco88_08_2dig <- isco88_08_clean %>%
+  mutate(isco08_2dig = stringr::str_sub(isco08, 1,2),
+         isco88_2dig = stringr::str_sub(isco88, 1,2)) %>%
+  #distinct(across(contains("2dig")), .keep_all = TRUE) %>%
+  select(contains("2dig"), "title08")
+
+match_isco88_08_2dig_list <- corresp(df = isco88_08_2dig,
+                                     country_code = isco88_2dig, 
+                                     international_code = isco08_2dig,
+                                     pad_vars = NULL,
+                                     check_matches = F)
+
+match_isco88_08_2dig_table <- match_isco88_08_2dig_list[[1]]  
+
+
 # save data ----
 if (TRUE) {
   

--- a/Support/Global/international_codes.R
+++ b/Support/Global/international_codes.R
@@ -401,7 +401,7 @@ psoc92_2dig <- psoc92_2dig_raw %>%
   mutate( psoc92 = isco88_sub_major)  %>%
   select(psoc92, isco88_sub_major, everything()) %>%
     # make manual changes
-  mutate(psoc92 = case_when(psoc92 == "61" ~ "62", # recode subsistence agriculture (62) to market-based (61)
+  mutate(psoc92 = case_when(psoc92 == "62" ~ "*removethis*", # substistence ag not listed in PSOC
                             TRUE ~ as.character(psoc92)),
          psoc92_description = NA_character_) %>%
   # add PSOC data
@@ -418,8 +418,8 @@ psoc92_2dig <- psoc92_2dig_raw %>%
   add_row(psoc92 = "02", isco88_sub_major = "51", 
           psoc92_description = "Housekeepers, Pensioners, Students") %>% # housekeepers etc to personal/protective services
   add_row(psoc92 = "09", isco88_sub_major = NA_character_, 
-          psoc92_description = "Not Classifiable and Other Occupations")  # Not classifiable to missing
-  
+          psoc92_description = "Not Classifiable and Other Occupations")  %>% # Not classifiable to missing
+  filter(psoc92 != "*removethis*")
 
 ### map isco08 colums ----
 ### The easiest way to introduce ISCO08 conversions is to include a isco08 column directly 

--- a/Support/Global/isic_isco_checks.R
+++ b/Support/Global/isic_isco_checks.R
@@ -1,0 +1,17 @@
+# isic_isco_check.R
+# Checks isic and isco non-missing values by year. Assumes you run main.R
+library(tidyverse)
+
+load(file = file.path(PHL, "PHL_data/GLD/population.Rdata"))
+     
+
+#check isic and isco
+sum(!is.na(phl$industrycat_isic))/nrow(phl) # 0.3520979 of cases are non missing
+sum(!is.na(phl$occup_isco))/nrow(phl) # 0.3465874 of cases are nonmissing
+
+sum.isic.isco <- phl %>%
+  group_by(year) %>%
+  summarize(industry_pct = sum(!is.na(industrycat_isic))/n(),
+            occup_pct    = sum(!is.na(occup_isco))/n()
+            )
+

--- a/Support/Global/isic_isco_checks.R
+++ b/Support/Global/isic_isco_checks.R
@@ -15,3 +15,7 @@ sum.isic.isco <- phl %>%
             occup_pct    = sum(!is.na(occup_isco))/n()
             )
 
+save(
+  sum.isic.isco,
+  file = file.path(PHL, "PHL_data/GLD/isic_isco_summary.Rdata")
+)

--- a/Support/Global/isic_isco_checks.R
+++ b/Support/Global/isic_isco_checks.R
@@ -6,8 +6,8 @@ load(file = file.path(PHL, "PHL_data/GLD/population.Rdata"))
      
 
 #check isic and isco
-sum(!is.na(phl$industrycat_isic))/nrow(phl) # 0.3520979 of cases are non missing
-sum(!is.na(phl$occup_isco))/nrow(phl) # 0.3465874 of cases are nonmissing
+sum(!is.na(phl$industrycat_isic))/nrow(phl) # 0.3650861 of cases are non missing
+sum(!is.na(phl$occup_isco))/nrow(phl) # 0.3576665 of cases are nonmissing
 
 sum.isic.isco <- phl %>%
   group_by(year) %>%

--- a/Support/Global/population_lfp.R
+++ b/Support/Global/population_lfp.R
@@ -47,6 +47,14 @@ sum.15.y <- phl2 %>%
 
 # add PSA data 
 # Source: https://psa.gov.ph/statistics/survey/labor-and-employment/labor-force-survey
+# Methodology:
+#   In cases where PSA publishes singles figures for each year, those figures are used.
+#   In cases where PSA does not publish figures for each year (ie, for each wave only),
+#   the simple mean is used to estimate the Labor FOrce Participation; the October figure 
+#   for population is used since the assumption is that it is most reflective of the final
+#   year estimate for population. Note that LFP figures are recorded in descending order
+#   ~ mean(Q4, Q3, Q2, Q1)
+#   
 sum.15.y <- sum.15.y %>%
   mutate(
     psa_lfp_15up = case_when(
@@ -54,7 +62,7 @@ sum.15.y <- sum.15.y %>%
       year == "2018" ~ 60.9,
       year == "2017" ~ 61.2,
       year == "2016" ~ 63.4,
-      year == "2015" ~ mean(),
+      year == "2015" ~ mean(c(63.3, 62.9, 64.6, 63.8)),
       year == "2014" ~ 64.4,
       year == "2013" ~ 63.9,
       year == "2012" ~ 64.2,
@@ -62,24 +70,24 @@ sum.15.y <- sum.15.y %>%
       year == "2010" ~ 64.1,
       year == "2009" ~ 64.0,
       year == "2008" ~ 63.6,
-      year == "2007" ~ ,
-      year == "2006" ~ ,
-      year == "2005" ~ ,
-      year == "2004" ~ ,
-      year == "2003" ~ ,
-      year == "2002" ~ ,
-      year == "2001" ~ ,
-      year == "2000" ~ ,
-      year == "1999" ~ ,
-      year == "1998" ~ ,
-      year == "1997" ~ 
+      year == "2007" ~ mean(c(63.2, 63.6, 64.5, 64.8)),
+      year == "2006" ~ mean(c(63.8, 64.6, 64.8, 63.6)),
+      year == "2005" ~ mean(c(64.8, 64.6, 64.8, 63.2)),
+      year == "2004" ~ mean(c( , , , )),
+      year == "2003" ~ mean(c( , , , )),
+      year == "2002" ~ mean(c( , , , )),
+      year == "2001" ~ mean(c( , , , )),
+      year == "2000" ~ mean(c( , , , )),
+      year == "1999" ~ mean(c( , , , )),
+      year == "1998" ~ mean(c( , , , )),
+      year == "1997" ~ mean(c( , , , ))
     ),
     psa_pop_15up = case_when(
       year == "2019" ~ 72931000,
       year == "2018" ~ 71339000,
       year == "2017" ~ 69896000,
       year == "2016" ~ 68125000,
-      year == "2015" ~ ,
+      year == "2015" ~ 66622000,
       year == "2014" ~ 62189000,
       year == "2013" ~ 61176000,
       year == "2012" ~ 62985000,
@@ -87,9 +95,9 @@ sum.15.y <- sum.15.y %>%
       year == "2010" ~ 60717000,
       year == "2009" ~ 59237000,
       year == "2008" ~ 57848000,
-      year == "2007" ~ ,
-      year == "2006" ~ ,
-      year == "2005" ~ ,
+      year == "2007" ~ 56864000,
+      year == "2006" ~ 55638000,
+      year == "2005" ~ 54797000,
       year == "2004" ~ ,
       year == "2003" ~ ,
       year == "2002" ~ ,

--- a/Support/Global/population_lfp.R
+++ b/Support/Global/population_lfp.R
@@ -1,0 +1,45 @@
+library(tidyverse)
+library(magrittr)
+source(file.path(code, "Global/import_surveys.R"))
+
+# sample df 
+df <- haven::read_dta(file.path(PHL, 
+                                "PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Data/Harmonized/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.dta"))
+
+phl <- import_surveys(PHL, vars = c("weight", "lstatus", "wave", "age"))
+
+if (TRUE) {
+  save(phl, file = file.path(PHL, "PHL_data/GLD/population.Rdata"))
+}
+
+phl2 <- phl %>%
+  mutate(
+    partic = case_when( (lstatus == 1 | lstatus == 2) ~ TRUE,
+                        (lstatus == 3) ~ FALSE )) 
+
+# population 15 and above
+sum.15 <- phl2 %>%
+  filter(age >= 15) %>%
+  group_by(year) %>%
+  summarize(pop = sum(weight))
+
+phl %>%
+  group_by(year) %>%
+  summarize(pop = sum(weight),
+            lfp = weighted.mean(partic, weight, na.rm = TRUE))
+
+# expanded population 
+## total
+pop <- sum(df$weight)
+## age 15 and above
+pop.15 <- df %>%
+  filter(age >= 15) %>%
+  pull(weight) %>%
+  sum
+
+# labor force participation 
+df <- df %>% 
+  mutate(
+    partic = case_when( (lstatus == 1 | lstatus == 2) ~ TRUE,
+                        (lstatus == 3) ~ FALSE )) 
+lfp <-  weighted.mean(df$partic, w = df$weight, na.rm = TRUE)

--- a/Support/Global/population_lfp.R
+++ b/Support/Global/population_lfp.R
@@ -2,65 +2,124 @@ library(tidyverse)
 library(magrittr)
 source(file.path(code, "Global/import_surveys.R"))
 
-# sample df 
-df <- haven::read_dta(file.path(PHL, 
-                                "PHL_2018_LFS/PHL_2018_LFS_v01_M_v01_A_GLD/Data/Harmonized/PHL_2018_LFS_v01_M_v01_A_GLD_ALL.dta"))
+phl <- import_surveys(PHL,
+                      vars = c("weight", "lstatus", "wave", "age",
+                               "industrycat_isic", "occup_isco"))
 
-phl <- import_surveys(PHL, vars = c("weight", "lstatus", "wave", "age"))
+# replace "" with NA
+phl <- phl %>% 
+  mutate(across(.cols = c("industrycat_isic", "occup_isco"), ~ na_if(., "")))
 
 if (TRUE) {
   save(phl, file = file.path(PHL, "PHL_data/GLD/population.Rdata"))
 }
 
+
+#check isic and isco
+sum(!is.na(phl$industrycat_isic))/nrow(phl) # 0.3520979 of cases are non missing
+sum(!is.na(phl$occup_isco))/nrow(phl) # 0.3465874 of cases are nonmissing
+
+sum.isic.isco <- phl %>%
+  group_by(year) %>%
+  summarize(industry_pct = sum(!is.na(industrycat_isic))/n(),
+            occup_pct    = sum(!is.na(occup_isco))/n())
+
+
 phl2 <- phl %>%
   mutate(
     partic = case_when( (lstatus == 1 | lstatus == 2) ~ TRUE,
-                        (lstatus == 3) ~ FALSE )) 
+                        (lstatus == 3) ~ FALSE ),
+    weight2= case_when( year <= 2007 ~ weight / 10000,
+                        TRUE         ~ weight
+          )) 
 
 
 sum.y <- phl2 %>%
   group_by(year) %>%
-  summarize(pop = sum(weight),
-            lfp = weighted.mean(partic, weight, na.rm = TRUE))
+  summarize(pop = sum(weight2),
+            lfp = weighted.mean(partic, weight2, na.rm = TRUE))
 
-sum.q <- phl2 %>%
-  group_by(year, wave) %>%
-  summarize(lfp = weighted.mean(partic, weight, na.rm = TRUE))
+# sum.q <- phl2 %>%
+#   group_by(year, wave) %>%
+#   summarize(lfp = weighted.mean(partic, weight, na.rm = TRUE))
 
 
 # for ages 15 and older 
 sum.15.y <- phl2 %>%
   filter(age >= 15) %>%
   group_by(year) %>%
-  summarize(lfp_15up = weighted.mean(partic, weight, na.rm = TRUE))
+  summarize(
+    pop_15up = sum(weight2),
+    lfp_15up = weighted.mean(partic, weight2, na.rm = TRUE)
+    )
 
-sum.15.q <- phl2 %>%
-  filter(age >= 15) %>%
-  group_by(year, wave) %>%
-  summarize(lfp_up = weighted.mean(partic, weight, na.rm = TRUE))
+# add PSA data 
+# Source: https://psa.gov.ph/statistics/survey/labor-and-employment/labor-force-survey
+sum.15.y <- sum.15.y %>%
+  mutate(
+    psa_lfp_15up = case_when(
+      year == "2019" ~ 61.3,
+      year == "2018" ~ 60.9,
+      year == "2017" ~ 61.2,
+      year == "2016" ~ 63.4,
+      year == "2015" ~ mean(),
+      year == "2014" ~ 64.4,
+      year == "2013" ~ 63.9,
+      year == "2012" ~ 64.2,
+      year == "2011" ~ 64.6,
+      year == "2010" ~ 64.1,
+      year == "2009" ~ 64.0,
+      year == "2008" ~ 63.6,
+      year == "2007" ~ ,
+      year == "2006" ~ ,
+      year == "2005" ~ ,
+      year == "2004" ~ ,
+      year == "2003" ~ ,
+      year == "2002" ~ ,
+      year == "2001" ~ ,
+      year == "2000" ~ ,
+      year == "1999" ~ ,
+      year == "1998" ~ ,
+      year == "1997" ~ 
+    ),
+    psa_pop_15up = case_when(
+      year == "2019" ~ 72931000,
+      year == "2018" ~ 71339000,
+      year == "2017" ~ 69896000,
+      year == "2016" ~ 68125000,
+      year == "2015" ~ ,
+      year == "2014" ~ 62189000,
+      year == "2013" ~ 61176000,
+      year == "2012" ~ 62985000,
+      year == "2011" ~ 61882000,
+      year == "2010" ~ 60717000,
+      year == "2009" ~ 59237000,
+      year == "2008" ~ 57848000,
+      year == "2007" ~ ,
+      year == "2006" ~ ,
+      year == "2005" ~ ,
+      year == "2004" ~ ,
+      year == "2003" ~ ,
+      year == "2002" ~ ,
+      year == "2001" ~ ,
+      year == "2000" ~ ,
+      year == "1999" ~ ,
+      year == "1998" ~ ,
+      year == "1997" ~ 
+    )
+  )
+
+# sum.15.q <- phl2 %>%
+#   filter(age >= 15) %>%
+#   group_by(year, wave) %>%
+#   summarize(lfp_up = weighted.mean(partic, weight, na.rm = TRUE))
 
 
 ## merge 
-sum.y %>% 
-  left_join(sum.15.y, by = "year", na_matches = "never")
+# sum.y %>% 
+#   left_join(sum.15.y, by = "year", na_matches = "never")
+# 
+# sum.q %>%
+#   left_join(sum.15.q, by = c("year", "wave"), na_matches = "never")
 
-sum.q %>%
-  left_join(sum.15.q, by = c("year", "wave"), na_matches = "never")
 
-
-
-# expanded population 
-## total
-pop <- sum(df$weight)
-## age 15 and above
-pop.15 <- df %>%
-  filter(age >= 15) %>%
-  pull(weight) %>%
-  sum
-
-# labor force participation 
-df <- df %>% 
-  mutate(
-    partic = case_when( (lstatus == 1 | lstatus == 2) ~ TRUE,
-                        (lstatus == 3) ~ FALSE )) 
-lfp <-  weighted.mean(df$partic, w = df$weight, na.rm = TRUE)

--- a/Support/Global/population_lfp.R
+++ b/Support/Global/population_lfp.R
@@ -15,14 +15,6 @@ if (TRUE) {
 }
 
 
-#check isic and isco
-sum(!is.na(phl$industrycat_isic))/nrow(phl) # 0.3520979 of cases are non missing
-sum(!is.na(phl$occup_isco))/nrow(phl) # 0.3465874 of cases are nonmissing
-
-sum.isic.isco <- phl %>%
-  group_by(year) %>%
-  summarize(industry_pct = sum(!is.na(industrycat_isic))/n(),
-            occup_pct    = sum(!is.na(occup_isco))/n())
 
 
 phl2 <- phl %>%

--- a/Support/Global/population_lfp.R
+++ b/Support/Global/population_lfp.R
@@ -17,16 +17,37 @@ phl2 <- phl %>%
     partic = case_when( (lstatus == 1 | lstatus == 2) ~ TRUE,
                         (lstatus == 3) ~ FALSE )) 
 
-# population 15 and above
-sum.15 <- phl2 %>%
-  filter(age >= 15) %>%
-  group_by(year) %>%
-  summarize(pop = sum(weight))
 
-phl %>%
+sum.y <- phl2 %>%
   group_by(year) %>%
   summarize(pop = sum(weight),
             lfp = weighted.mean(partic, weight, na.rm = TRUE))
+
+sum.q <- phl2 %>%
+  group_by(year, wave) %>%
+  summarize(lfp = weighted.mean(partic, weight, na.rm = TRUE))
+
+
+# for ages 15 and older 
+sum.15.y <- phl2 %>%
+  filter(age >= 15) %>%
+  group_by(year) %>%
+  summarize(lfp_15up = weighted.mean(partic, weight, na.rm = TRUE))
+
+sum.15.q <- phl2 %>%
+  filter(age >= 15) %>%
+  group_by(year, wave) %>%
+  summarize(lfp_up = weighted.mean(partic, weight, na.rm = TRUE))
+
+
+## merge 
+sum.y %>% 
+  left_join(sum.15.y, by = "year", na_matches = "never")
+
+sum.q %>%
+  left_join(sum.15.q, by = c("year", "wave"), na_matches = "never")
+
+
 
 # expanded population 
 ## total


### PR DESCRIPTION
Produces the code to generate the keys and merge sequences necessary to incorporate the ISIC and ISCO data stored as 2-digits instead of 4-digits