### PR TITLE
Include link to correspondence dta

### DIFF
--- a/Support/B - Country Survey Details/ZAF/QLFS/Correspondence_National_International_Classifications.md
+++ b/Support/B - Country Survey Details/ZAF/QLFS/Correspondence_National_International_Classifications.md
@@ -20,6 +20,8 @@ The original variable `Q42OCCUPATION` in QLFS codes occupations is at four-digit
 
 Note that the only exception to the "N.C.E." grouping rule is category "*215 Physical sciences technologists*" in SASCO 2003, as no category 215 in ISCO-88 can be a perfect match for it. The solution is to map "*215 Physical sciences technologists*" to category *"210 Physical, mathematical and engineering science professionals"* in ISCO-88.
 
+In the harmonization code, the correspondence between SASCO 2003 and ISCO-88 is made [using this conversion `.dta` file](utilities/isco88_sasco03_mapping.dta)
+
 ## Correspondence in industry classification
 
 The original variable `Q43INDUSTRY` in QLFS coded industries is at three-digit level. The [online documentation of SIC 5](http://www.statssa.gov.za/additional_services/sic/descrip6.htm) provides a conversion table between SIC 5 and ISIC Rev.3, although only at two-digit level. As shown in the screenshot below, in most cases, the harmonization would be a one-to-one exclusive matching process, i.e. SIC \#11 will be mapped to ISIC \#01. But in some cases, the relationship is not exclusive but multiple in ISIC to one in SIC, i.e. SIC \#15 and SIC \#16 match SIC \#30. The solution is to go to a lower three-digit level in SIC to find minor-groups with narrower definition for each category, \#15 and \#16 in this case, in ISIC.


### PR DESCRIPTION
For SASCO 2003 to ISCO-88 the correspondence is not manually coded but uses an external .dta file. This file is given to users in the utilities folder but the text did not refer to it. Added that.