### PR TITLE
Phl patch ver update

### DIFF
--- a/GLD/PHL/PHL_2000_LFS/PHL_2000_LFS_v01_M_v02_A_GLD/Programs/PHL_2000_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2000_LFS/PHL_2000_LFS_v01_M_v02_A_GLD/Programs/PHL_2000_LFS_v01_M_v02_A_GLD_ALL.do
@@ -76,7 +76,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	stata		"`main'\Data\Stata"

--- a/GLD/PHL/PHL_2001_LFS/PHL_2001_LFS_v01_M_v02_A_GLD/Programs/PHL_2001_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2001_LFS/PHL_2001_LFS_v01_M_v02_A_GLD/Programs/PHL_2001_LFS_v01_M_v02_A_GLD_ALL.do
@@ -76,7 +76,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -1156,15 +1156,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2002_LFS/PHL_2002_LFS_v01_M_v02_A_GLD/Programs/PHL_2002_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2002_LFS/PHL_2002_LFS_v01_M_v02_A_GLD/Programs/PHL_2002_LFS_v01_M_v02_A_GLD_ALL.do
@@ -76,7 +76,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -121,7 +121,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2002 APR2002 JUL2002 OCT2002) generate(round) // survey names
 
 
@@ -1133,15 +1133,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2003_LFS/PHL_2003_LFS_v01_M_v02_A_GLD/Programs/PHL_2003_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2003_LFS/PHL_2003_LFS_v01_M_v02_A_GLD/Programs/PHL_2003_LFS_v01_M_v02_A_GLD_ALL.do
@@ -76,7 +76,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 	   "Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	stata		"`main'\Data\Stata"
@@ -88,9 +88,6 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
 	local 	weightvar 	rfadj // final weightvar
-
-** LOG FILE
-	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
@@ -121,7 +118,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2003 APR2003 JUL2003 OCT2003) generate(round) // survey names
 
 
@@ -1296,15 +1293,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2004_LFS/PHL_2004_LFS_v01_M_v02_A_GLD/Programs/PHL_2004_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2004_LFS/PHL_2004_LFS_v01_M_v02_A_GLD/Programs/PHL_2004_LFS_v01_M_v02_A_GLD_ALL.do
@@ -76,7 +76,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -121,7 +121,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2004 APR2004 JUL2004 OCT2004) generate(round) // survey names
 
 
@@ -1264,15 +1264,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2005_LFS/PHL_2005_LFS_v01_M_v02_A_GLD/Programs/PHL_2005_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2005_LFS/PHL_2005_LFS_v01_M_v02_A_GLD/Programs/PHL_2005_LFS_v01_M_v02_A_GLD_ALL.do
@@ -76,7 +76,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -121,7 +121,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2005 APR2005 JUL2005 OCT2005) generate(round) // survey names
 
 
@@ -1140,15 +1140,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2006_LFS/PHL_2006_LFS_v01_M_v02_A_GLD/Programs/PHL_2006_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2006_LFS/PHL_2006_LFS_v01_M_v02_A_GLD/Programs/PHL_2006_LFS_v01_M_v02_A_GLD_ALL.do
@@ -75,7 +75,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -87,9 +87,6 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
 	local 	weightvar 	fwgt // final weightvar
-
-** LOG FILE
-	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
@@ -120,7 +117,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2006 APR2006 JUL2006 OCT2006) generate(round) // survey names
 
 
@@ -1295,15 +1292,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2007_LFS/PHL_2007_LFS_v01_M_v02_A_GLD/Programs/PHL_2007_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2007_LFS/PHL_2007_LFS_v01_M_v02_A_GLD/Programs/PHL_2007_LFS_v01_M_v02_A_GLD_ALL.do
@@ -75,7 +75,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -120,7 +120,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2007 APR2007 JUL2007 OCT2007) generate(round) // survey names
 
 
@@ -1294,15 +1294,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2008_LFS/PHL_2008_LFS_v01_M_v02_A_GLD/Programs/PHL_2008_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2008_LFS/PHL_2008_LFS_v01_M_v02_A_GLD/Programs/PHL_2008_LFS_v01_M_v02_A_GLD_ALL.do
@@ -75,7 +75,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -120,7 +120,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2008 APR2008 JUL2008 OCT2008) generate(round) // survey names
 
 
@@ -1133,15 +1133,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2009_LFS/PHL_2009_LFS_v01_M_v02_A_GLD/Programs/PHL_2009_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2009_LFS/PHL_2009_LFS_v01_M_v02_A_GLD/Programs/PHL_2009_LFS_v01_M_v02_A_GLD_ALL.do
@@ -75,7 +75,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -120,7 +120,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2009 APR2009 JUL2009 OCT2009) generate(round) // survey names
 
 
@@ -1136,15 +1136,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2011_LFS/PHL_2011_LFS_v01_M_v02_A_GLD/Programs/PHL_2011_LFS_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2011_LFS/PHL_2011_LFS_v01_M_v02_A_GLD/Programs/PHL_2011_LFS_v01_M_v02_A_GLD_ALL.do
@@ -75,7 +75,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	drop 	 = 1 		// 1 to drop variables with all missing values, 0 otherwise
 
 
-	local 	year 		"Y:\GLD\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
+	local 	year 		"Z:\GLD-Harmonization\551206_TM\\`cty3'\\`cty3'_`surv_yr'_LFS" // top data folder
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
@@ -87,9 +87,6 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
 	local 	weightvar 	fwgt // final weightvar
-
-** LOG FILE
-	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
@@ -120,7 +117,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
 		, clear surveys(JAN2011 APR2011 JUL2011 OCT2011) generate(round) // survey names
 
 
@@ -1138,15 +1135,13 @@ foreach v of local ed_var {
 
 
 *<_occup_skill_>
-	gen 			occup_skill = .
-	replace 		occup_skill = 1 	if occup == 9
-	replace 		occup_skill = 2 	if occup >=4 & occup <= 8
-	replace 		occup_skill = 3 	if occup >=1 & occup <= 3
-	replace 		occup_skill = 4 	if occup == 10
-	replace 		occup_skill = 5 	if occup == 99
-	la de 			lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill" 4 "Armed Forces" 5 "Not Classified"
-	label values 	occup_skill lblskill
-	label var 		occup_skill "Skill based on ISCO standard primary job 7 day recall"
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
+	replace occup_skill=. if lstatus!=1
+	replace occup_skill=. if !inrange(occup, 1, 9)
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
 *</_occup_skill_>
 
 

--- a/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v03_A_GLD/Programs/PHL_2012_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2012_LFS/PHL_2012_LFS_v01_M_v03_A_GLD/Programs/PHL_2012_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2012_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,10 +13,10 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2012 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2012] </_Data collection from_>
+<_Data collection to_>			[10/2012] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
@@ -30,13 +30,14 @@
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
 <_ISCO Version_>				ISCO 88 </_ISCO Version_>
 <_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-24] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2012			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,30 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	pwgt // final weightvar
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFSjan12.dta"'
+	local round2 `"`stata'\LFSapr12.dta"'
+	local round3 `"`stata'\LFSjul12.dta"'
+	local round4 `"`stata'\LFS OCT2012.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_updated.dta"'  // 4 digits
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'  // 2 digits
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -117,8 +118,8 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		using `"`main'\Doc\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
+		, clear surveys(JAN2012 APR2012 JUL2012 OCT2012) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -163,7 +164,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +182,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -231,10 +232,8 @@ replace int_month = 10 	if round == 4
 ** HOUSEHOLD IDENTIFICATION NUMBER
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-
-
-	loc idhvars 	hhnum   							// store idh vars in local
-
+** HOUSEHOLD IDENTIFICATION NUMBER
+	loc idhvars 	hhnum 	// store idh vars in local
 
 	ds `idhvars',  	has(type numeric)					// filter out numeric variables in local
 	loc numlist 	= r(varlist)						// store numeric vars in local
@@ -274,10 +273,11 @@ replace int_month = 10 	if round == 4
 	bys idh: gen n_fam = _n								// generate family member number
 
 	* repeat same process from above, but only with n_fam.
-	* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
-	*	so, not following processing for sorting numeric/non-numeric variables.
+	* 	note, 2012 does not have a valid, non-missing line number variable that is present on all
+	* observations across all years, so in this year I will generate a "line number" variable myself
+	* by using the row number within each household grouping.
 
-	loc idpvars 	c101_lno 							// store relevant idp vars in local
+	loc idpvars 	n_fam	 							// store relevant idp vars in local
 	ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
 	loc rlist 		= r(varlist)						// store numeric vars in local
 
@@ -303,7 +303,7 @@ replace int_month = 10 	if round == 4
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
 
-
+	rename hhid hhid_orig
 	gen  hhid = idh  									// make hhid from idh in module
 	label var hhid "Household ID"
 
@@ -320,8 +320,8 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	rename 		weight weight_orig
+	gen 		weight = pwgt / 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
@@ -367,7 +367,7 @@ replace int_month = 10 	if round == 4
 
 *<_urban_>
 	gen byte 		urban = .
-	replace 		urban = urb2k70
+	replace 		urban = urb2k1970
 	recode 			urban (2 = 0) 		// change rural=2 to rural=0
 	label var 		urban "Location is urban"
 	la de 			lblurban 1 "Urban" 0 "Rural"
@@ -381,7 +381,7 @@ replace int_month = 10 	if round == 4
 	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
 
 </_subnatid1> */
-	gen byte 		subnatid1 = reg
+	gen byte 		subnatid1 = creg
 	label de 		lblsubnatid1 	///
 					 1   "1 - Ilocos"			///
 					 2	 "2 - Cagayan Valley"	///
@@ -572,7 +572,7 @@ replace int_month = 10 	if round == 4
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+	gen byte 		marital = c08_mstat
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -717,7 +717,7 @@ label var ed_mod_age "Education module application age"
 *</_ed_mod_age_>
 
 *<_school_>
-	gen byte school= a02_csch
+	gen byte school= a02_cursch
 	recode school (2 = 0)		// 2 was "no", recode to 0. Keep 1=Yes same.
 	label var school "Attending school"
 	la de lblschool 0 "No" 1 "Yes"
@@ -744,15 +744,17 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte educat7=.
 
+	replace educat7=1 if j12c09_grade==0 | j12c09_grade == 10 	// "No education" and "Preschool" -> "No Education"
+	replace educat7=2 if j12c09_grade>=210 &  j12c09_grade<=260	// Grades 1-7 to "Primary Incomplete"
+	replace educat7=3 if j12c09_grade==280						// "Elementary Graduate" to "Primary Complete"
+	replace educat7=4 if j12c09_grade>=310 &  j12c09_grade<=340 	// First-Fourth year in High school -> "secondary incomplete"
+	replace educat7=5 if j12c09_grade==350						// "High school graduate" -> "secondary complete"
+	replace educat7=6 if j12c09_grade>=410 &  j12c09_grade<=501 	// Post secondary + Basic Programs -> "Higher secondary not uni"
+	replace educat7=6 if j12c09_grade>=502 & 	j12c09_grade<=699	// Basic Program degrees to "Higher secondary not uni"
+	replace educat7=7 if j12c09_grade>= 810 & j12c09_grade <= . // all labelled uni levels Advanced Degree" -> "University"
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +795,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = j12c09_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -881,7 +883,7 @@ foreach v of local ed_var {
 
 {
 *<_lstatus_>
-	gen byte 		lstatus = newempst
+	gen byte 		lstatus = newempstat
 	replace 		lstatus = . if age < minlaborage
 	label var 		lstatus "Labor status"
 	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF" // raw values always same as new
@@ -892,8 +894,8 @@ foreach v of local ed_var {
 *<_potential_lf_>
 	gen byte 		potential_lf = 0
 
-	replace 		potential_lf = 1 if (c37_avil == 1 & c38_lokw == 2) ///
-										| (c37_avil == 2 & c38_lokw == 1)
+	replace 		potential_lf = 1 if (c37_avail == 1 & c38_lookw == 2) ///
+										| (c37_avail == 2 & c38_lookw == 1)
 	replace 		potential_lf = . if age < minlaborage & age != .
 	replace 		potential_lf = . if lstatus != 3
 	label var 		potential_lf "Potential labour force status"
@@ -905,7 +907,7 @@ foreach v of local ed_var {
 *<_underemployment_>
 	gen byte 		underemployment = 0
 
-	replace 		underemployment = 1 if c23_pwmr == 1
+	replace 		underemployment = 1 if c23_pwmore == 1
 	replace 		underemployment = . if age < minlaborage & age != .
 	replace 		underemployment = . if lstatus != 1
 	label var 		underemployment "Underemployment status"
@@ -916,11 +918,11 @@ foreach v of local ed_var {
 
 *<_nlfreason_>
 	gen byte 		nlfreason= .
-	replace 		nlfreason=1 	if c42_wynt==8
-	replace 		nlfreason=2 	if c42_wynt==7
-	replace 		nlfreason=3 	if c42_wynt==6
-	replace 		nlfreason=4 	if c42_wynt==3
-	replace 		nlfreason=5 	if c42_wynt==1 | c42_wynt==2 | c42_wynt==4 | c42_wynt==5 | c42_wynt==9
+	replace 		nlfreason=1 	if c42_wynot==8
+	replace 		nlfreason=2 	if c42_wynot==7
+	replace 		nlfreason=3 	if c42_wynot==6
+	replace 		nlfreason=4 	if c42_wynot==3
+	replace 		nlfreason=5 	if c42_wynot==1 | c42_wynot==2 | c42_wynot==4 | c42_wynot==5 | c42_wynot==9
 	replace 		nlfreason=. 	if lstatus!=3 		// restricts universe to non-labor force
 	label var 		nlfreason "Reason not in the labor force"
 	la de 			lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
@@ -929,7 +931,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_l_>
-	gen byte 		unempldur_l=c40_wks/4.2
+	gen byte 		unempldur_l=c40_weeks/4.2
 	label var 		unempldur_l "Unemployment duration (months) lower bracket"
 	replace 		unempldur_l=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -937,7 +939,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_u_>
-	gen byte 		unempldur_u=c40_wks/4.2
+	gen byte 		unempldur_u=c40_weeks/4.2
 	label var 		unempldur_u "Unemployment duration (months) upper bracket"
 	replace 		unempldur_u=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -951,10 +953,10 @@ foreach v of local ed_var {
 {
 *<_empstat_>
 	gen byte 		empstat=.
-	replace 		empstat=1 	if c19pclas==0 | c19pclas==1 | c19pclas==2 | c19pclas==5
-	replace 		empstat=2 	if c19pclas==6
-	replace 		empstat=3	if c19pclas==4
-	replace 		empstat=4 	if c19pclas==3
+	replace 		empstat=1 	if c19_pclass==0 | c19_pclass==1 | c19_pclass==2 | c19_pclass==5
+	replace 		empstat=2 	if c19_pclass==6
+	replace 		empstat=3	if c19_pclass==4
+	replace 		empstat=4 	if c19_pclass==3
 	replace 		empstat=. 	if lstatus!=1 	// includes universe restriction
 	label var 		empstat 	"Employment status during past week primary job 7 day recall"
 	la de 			lblempstat 	1 "Paid employee" ///
@@ -968,8 +970,8 @@ foreach v of local ed_var {
 
 *<_ocusec_>
 	gen byte 		ocusec = .
-	replace 		ocusec = 1 	if c19pclas == 2
-	replace 		ocusec = 2 	if inlist(c19pclas, 0, 1, 3, 4, 5, 6)
+	replace 		ocusec = 1 	if c19_pclass == 2
+	replace 		ocusec = 2 	if inlist(c19_pclass, 0, 1, 3, 4, 5, 6)
 
 	label var 		ocusec 		"Sector of activity primary job 7 day recall"
 	la de 			lblocusec 	1 "Public Sector, Central Government, Army" ///
@@ -987,6 +989,11 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary */
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary */
+
 	loc matchvar   	c18_pkb
 	loc n 			1
 
@@ -997,46 +1004,59 @@ foreach v of local ed_var {
 		if (`len' == 1) {
 															// run this if == 1 (ie, if industry_orig is numeric)
 			tostring industry_orig	///						// make the numeric vars strings
-				, generate(industry_orig_str) ///			// gen a variable with this prefix
+				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
 				force //
+
+
 		}
 
 
 	// merge sub-module with isic key
 
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
+	gen class = `matchvar'
+	tostring 	class ///
+				, format(`"%04.0f"') replace
+
 
 	merge 		m:1 ///
-				psic_2dig ///
+				class ///
 				using `isic_key' ///
 				, generate(isic_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4	isic4_`n'
+	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	tab 		isic_merge_`n' 		if `matchvar' != .
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+
+	gen 		industrycat_isic = isic4_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		class 				// no longer needed, maintained in matchvar
+
+
+	*// industrycat_isic already generated above in submodule
+	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
 	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	replace 		industrycat10=1 	if c18_pkb >= 100 	& c18_pkb <= 399	// "Agriculture, Forestry, Fishing" coded to "Agriculture"
+	replace 		industrycat10=2 	if c18_pkb >= 500 	& c18_pkb <= 999	// "Mining and Quarrying" coded to "Mining"
+	replace 		industrycat10=3 	if c18_pkb >= 1000 	& c18_pkb <= 3399 	// "Manufacturing" coded to "Manufacturing"
+	replace 		industrycat10=4 	if c18_pkb >= 3500 	& c18_pkb <= 3900	// "Water supply, sewerage, etc" coded to "Public Utiltiy"
+	replace 		industrycat10=5 	if c18_pkb >= 4100 	& c18_pkb <= 4399	// "Construction" coded to "Construction"
+	replace 		industrycat10=6 	if c18_pkb >= 4500 	& c18_pkb <= 4799	// "Wholesale/retail, repair of vehicles" to "Commerce"
+	replace 		industrycat10=7 	if c18_pkb >= 4900 	& c18_pkb <= 5399	// "Transport+storage" to "Transport". UN codes include storage
+	replace 		industrycat10=6 	if c18_pkb >= 5500 	& c18_pkb <= 5699	// "Accommodation+Food" to "Commerce"
+	replace 		industrycat10=7 	if c18_pkb >= 5800 	& c18_pkb <= 6399	// "Information+communication" to "Transport/Communication"
+	replace 		industrycat10=8 	if c18_pkb >= 6400 	& c18_pkb <= 8299	// "Misc Business Services" to "Business Services"
+	replace 		industrycat10=9 	if c18_pkb >= 8400 	& c18_pkb <= 8499	// "public administration/defense" to "public administration"
+	replace 		industrycat10=10	if c18_pkb >= 8500 	& c18_pkb <= 9950	// "Other services" including direct education to "other"
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1061,7 +1081,7 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_>
-	gen 			occup_orig = c16_proc
+	gen 			occup_orig = c16_procc
 	label var 		occup_orig "Original occupation record primary job 7 day recall"
 	replace 		occup_orig=. if lstatus!=1 			// restrict universe to employed only
 	replace 		occup_orig=. if age < minlaborage	// restrict universe to working age
@@ -1069,7 +1089,9 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-	loc matchvar   	c16_proc
+* in 2012, raw variable is numeric, 4-digits, but since there is no provided PSOC to ISCO
+* conversion, at 4 digits, substring to 2 and match at 2
+	loc matchvar   	c16_procc
 	loc n 			1
 
 	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1086,9 +1108,11 @@ foreach v of local ed_var {
 
 	// merge sub-module with isco key
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
+	gen psoc92_4dig = `matchvar'
+	tostring 	psoc92_4dig ///
+				, format(`"%04.0f"') replace
+
+	gen psoc92  = substr(psoc92_4dig, 1,2)
 
 	merge 		m:1 ///
 				psoc92 ///
@@ -1107,11 +1131,14 @@ foreach v of local ed_var {
 
 
 *<_occup_>
+	* in 2012, raw variable is numeric, 4-digits, but since there is no provided PSOC to ISCO
+	* conversion, there is no occup_isco
+
 	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	gen byte occup=floor(c16_procc/1000)		// this handles most of recoding automatically.
+	recode occup 0 = 10	if 	c16_procc<=129 	// recode "armed forces" to appropriate label
+	recode occup 0 = 99	if 	(c16_procc == 930) // recode "Not classifiable occupations"
+
 
 	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
 	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
@@ -1146,7 +1173,7 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_>
-	gen 			double wage_no_compen = c27_pbsc
+	gen 			double wage_no_compen = c27_pbasic
 	replace 		wage_no_compen = . if 	wage_no_compen == 99999
 	label var 		wage_no_compen "Last wage payment primary job 7 day recall"
 *</_wage_no_compen_>
@@ -1173,7 +1200,7 @@ foreach v of local ed_var {
 
 
 *<_whours_>
-	gen whours 		= c22_phrs
+	gen whours 		= c22_phours
 	label var whours "Hours of work in last week primary job 7 day recall"
     replace 		whours = 84 	if whours > 84 & whours != . 	// replace unrealistic work weeks
 *</_whours_>
@@ -1247,9 +1274,6 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2010 has no secondary job information.
-*/
 
 {
 *<_empstat_2_>
@@ -1273,6 +1297,9 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary */
+
 	loc matchvar   	j03_okb
 	loc n 			2
 
@@ -1281,49 +1308,65 @@ foreach v of local ed_var {
 	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
 
 		if (`len' == 1) {
-															// run this if == 1 (ie, if industry_orig is numeric)
+															// run this if == 1 (ie, if industry_orig_2 is numeric)
 			tostring industry_orig_2	///						// make the numeric vars strings
-				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
+				, generate(industry_orig_str) ///			// gen a variable with this prefix
 				force //
+
+
 		}
 
 
 	// merge sub-module with isic key
 
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
+	gen class = `matchvar'
+	tostring 	class ///
+				, format(`"%04.0f"') replace
+
 
 	merge 		m:1 ///
-				psic_2dig ///
+				class ///
 				using `isic_key' ///
 				, generate(isic_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4	isic4_`n'
+	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	tab 		isic_merge_`n' 		if `matchvar' != .
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+
+	gen 		industrycat_isic_2 = isic4_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		class 				// no longer needed, maintained in matchvar
+
+
+	*// industrycat_isic already generated above in submodule
+	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+
+
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
 	gen byte 		industrycat10_2 = .
 
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
+
+	replace 		industrycat10_2=1 	if j03_okb >= 100 	& j03_okb <= 399	// "Agriculture, Forestry, Fishing" coded to "Agriculture"
+	replace 		industrycat10_2=2 	if j03_okb >= 500 	& j03_okb <= 999	// "Mining and Quarrying" coded to "Mining"
+	replace 		industrycat10_2=3 	if j03_okb >= 1000 	& j03_okb <= 3399 	// "Manufacturing" coded to "Manufacturing"
+	replace 		industrycat10_2=4 	if j03_okb >= 3500 	& j03_okb <= 3900	// "Water supply, sewerage, etc" coded to "Public Utiltiy"
+	replace 		industrycat10_2=5 	if j03_okb >= 4100 	& j03_okb <= 4399	// "Construction" coded to "Construction"
+	replace 		industrycat10_2=6 	if j03_okb >= 4500 	& j03_okb <= 4799	// "Wholesale/retail, repair of vehicles" to "Commerce"
+	replace 		industrycat10_2=7 	if j03_okb >= 4900 	& j03_okb <= 5399	// "Transport+storage" to "Transport". UN codes include storage
+	replace 		industrycat10_2=6 	if j03_okb >= 5500 	& j03_okb <= 5699	// "Accommodation+Food" to "Commerce"
+	replace 		industrycat10_2=7 	if j03_okb >= 5800 	& j03_okb <= 6399	// "Information+communication" to "Transport/Communication"
+	replace 		industrycat10_2=8 	if j03_okb >= 6400 	& j03_okb <= 8299	// "Misc Business Services" to "Business Services"
+	replace 		industrycat10_2=9 	if j03_okb >= 8400 	& j03_okb <= 8499	// "public administration/defense" to "public administration"
+	replace 		industrycat10_2=10	if j03_okb >= 8500 	& j03_okb <= 9950	// "Other services" including direct education to "other"
+
 
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
@@ -1339,13 +1382,13 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_2_>
-	gen 			occup_orig_2 = j02_otoc
+	gen 			occup_orig_2 = j02_otocc
 	label var 		occup_orig_2 "Original occupation record secondary job 7 day recall"
 *</_occup_orig_2_>
 
 
 *<_occup_isco_2_>
-	loc matchvar   	j02_otoc
+	loc matchvar   	j02_otocc
 	loc n 			2
 
 	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
@@ -1390,10 +1433,10 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
-							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+	gen byte 		occup_2=floor(j02_otocc/1000)		// this handles most of recoding automatically.
+	recode 			occup_2 0 = 10	if 	j02_otocc<=129 	// recode "armed forces" to appropriate label
+	recode 			occup_2 0 = 99	if 	(j02_otocc == 930) // recode "Not classifiable occupations"
+
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup
@@ -1401,14 +1444,14 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen 			double wage_no_compen_2 = c36_obic
+	gen 			double wage_no_compen_2 = j07_obasic
 	replace 		wage_no_compen_2 = . if wage_no_compen_2 == 99999
 	label var 		wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obis
+	gen byte 		unitwage_2 = j06_obasis
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly
@@ -1421,7 +1464,7 @@ foreach v of local ed_var {
 
 
 *<_whours_2_>
-	gen 			whours_2 = j05_ohrs
+	gen 			whours_2 = j05_ohours
 	label var 		whours_2 "Hours of work in last week secondary job 7 day recall"
 *</_whours_2_>
 

--- a/GLD/PHL/PHL_2013_LFS/PHL_2013_LFS_v01_M_v03_A_GLD/Programs/PHL_2013_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2013_LFS/PHL_2013_LFS_v01_M_v03_A_GLD/Programs/PHL_2013_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2013_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,10 +13,10 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2013 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2013] </_Data collection from_>
+<_Data collection to_>			[10/2013] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
@@ -30,13 +30,14 @@
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
 <_ISCO Version_>				ISCO 88 </_ISCO Version_>
 <_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-26] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2013			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,33 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	pwgt // final weightvar
+
+** LOG FILE
+	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFSjan13.dta"'
+	local round2 `"`stata'\LFSapr13.dta"'
+	local round3 `"`stata'\LFSjul13.dta"'
+	local round4 `"`stata'\LFS OCT2013.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_updated.dta"' // 4 digit
+	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"' // 2 digit
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -118,7 +122,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
 		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		, clear surveys(JAN2013 APR2013 JUL2013 OCT2013) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -163,7 +167,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +185,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -231,8 +235,6 @@ replace int_month = 10 	if round == 4
 ** HOUSEHOLD IDENTIFICATION NUMBER
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-
-
 	loc idhvars 	hhnum   							// store idh vars in local
 
 
@@ -277,7 +279,7 @@ replace int_month = 10 	if round == 4
 	* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
 	*	so, not following processing for sorting numeric/non-numeric variables.
 
-	loc idpvars 	c101_lno 							// store relevant idp vars in local
+	loc idpvars 	cc101_lno 							// store relevant idp vars in local
 	ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
 	loc rlist 		= r(varlist)						// store numeric vars in local
 
@@ -303,7 +305,7 @@ replace int_month = 10 	if round == 4
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
 
-
+	rename hhid hhid_orig
 	gen  hhid = idh  									// make hhid from idh in module
 	label var hhid "Household ID"
 
@@ -320,8 +322,8 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	rename 		weight weight_orig
+	gen 		weight = pwgt / 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
@@ -367,7 +369,7 @@ replace int_month = 10 	if round == 4
 
 *<_urban_>
 	gen byte 		urban = .
-	replace 		urban = urb2k70
+	replace 		urban = urb2k1970
 	recode 			urban (2 = 0) 		// change rural=2 to rural=0
 	label var 		urban "Location is urban"
 	la de 			lblurban 1 "Urban" 0 "Rural"
@@ -381,7 +383,7 @@ replace int_month = 10 	if round == 4
 	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
 
 </_subnatid1> */
-	gen byte 		subnatid1 = reg
+	gen byte 		subnatid1 = creg
 	label de 		lblsubnatid1 	///
 					 1   "1 - Ilocos"			///
 					 2	 "2 - Cagayan Valley"	///
@@ -572,7 +574,7 @@ replace int_month = 10 	if round == 4
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+	gen byte 		marital = c08_mstat
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -717,7 +719,7 @@ label var ed_mod_age "Education module application age"
 *</_ed_mod_age_>
 
 *<_school_>
-	gen byte school= a02_csch
+	gen byte school= a02_cursch
 	recode school (2 = 0)		// 2 was "no", recode to 0. Keep 1=Yes same.
 	label var school "Attending school"
 	la de lblschool 0 "No" 1 "Yes"
@@ -744,15 +746,17 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte educat7=.
 
+	replace educat7=1 if j12c09_grade==0 | j12c09_grade == 10 	// "No education" and "Preschool" -> "No Education"
+	replace educat7=2 if j12c09_grade>=210 &  j12c09_grade<=260	// Grades 1-7 to "Primary Incomplete"
+	replace educat7=3 if j12c09_grade==280						// "Elementary Graduate" to "Primary Complete"
+	replace educat7=4 if j12c09_grade>=310 &  j12c09_grade<=340 	// First-Fourth year in High school -> "secondary incomplete"
+	replace educat7=5 if j12c09_grade==350						// "High school graduate" -> "secondary complete"
+	replace educat7=6 if j12c09_grade>=410 &  j12c09_grade<=501 	// Post secondary + Basic Programs -> "Higher secondary not uni"
+	replace educat7=6 if j12c09_grade>=502 & 	j12c09_grade<=699	// Basic Program degrees to "Higher secondary not uni"
+	replace educat7=7 if j12c09_grade>= 810 & j12c09_grade <= . // all labelled uni levels Advanced Degree" -> "University"
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +797,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = j12c09_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -881,7 +885,7 @@ foreach v of local ed_var {
 
 {
 *<_lstatus_>
-	gen byte 		lstatus = newempst
+	gen byte 		lstatus = newempstat
 	replace 		lstatus = . if age < minlaborage
 	label var 		lstatus "Labor status"
 	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF" // raw values always same as new
@@ -892,8 +896,8 @@ foreach v of local ed_var {
 *<_potential_lf_>
 	gen byte 		potential_lf = 0
 
-	replace 		potential_lf = 1 if (c37_avil == 1 & c38_lokw == 2) ///
-										| (c37_avil == 2 & c38_lokw == 1)
+	replace 		potential_lf = 1 if (c37_avail == 1 & c38_lookw == 2) ///
+										| (c37_avail == 2 & c38_lookw == 1)
 	replace 		potential_lf = . if age < minlaborage & age != .
 	replace 		potential_lf = . if lstatus != 3
 	label var 		potential_lf "Potential labour force status"
@@ -905,7 +909,7 @@ foreach v of local ed_var {
 *<_underemployment_>
 	gen byte 		underemployment = 0
 
-	replace 		underemployment = 1 if c23_pwmr == 1
+	replace 		underemployment = 1 if c23_pwmore == 1
 	replace 		underemployment = . if age < minlaborage & age != .
 	replace 		underemployment = . if lstatus != 1
 	label var 		underemployment "Underemployment status"
@@ -916,11 +920,11 @@ foreach v of local ed_var {
 
 *<_nlfreason_>
 	gen byte 		nlfreason= .
-	replace 		nlfreason=1 	if c42_wynt==8
-	replace 		nlfreason=2 	if c42_wynt==7
-	replace 		nlfreason=3 	if c42_wynt==6
-	replace 		nlfreason=4 	if c42_wynt==3
-	replace 		nlfreason=5 	if c42_wynt==1 | c42_wynt==2 | c42_wynt==4 | c42_wynt==5 | c42_wynt==9
+	replace 		nlfreason=1 	if c42_wynot==8
+	replace 		nlfreason=2 	if c42_wynot==7
+	replace 		nlfreason=3 	if c42_wynot==6
+	replace 		nlfreason=4 	if c42_wynot==3
+	replace 		nlfreason=5 	if c42_wynot==1 | c42_wynot==2 | c42_wynot==4 | c42_wynot==5 | c42_wynot==9
 	replace 		nlfreason=. 	if lstatus!=3 		// restricts universe to non-labor force
 	label var 		nlfreason "Reason not in the labor force"
 	la de 			lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
@@ -929,7 +933,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_l_>
-	gen byte 		unempldur_l=c40_wks/4.2
+	gen byte 		unempldur_l=c40_weeks/4.2
 	label var 		unempldur_l "Unemployment duration (months) lower bracket"
 	replace 		unempldur_l=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -937,7 +941,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_u_>
-	gen byte 		unempldur_u=c40_wks/4.2
+	gen byte 		unempldur_u=c40_weeks/4.2
 	label var 		unempldur_u "Unemployment duration (months) upper bracket"
 	replace 		unempldur_u=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -951,10 +955,10 @@ foreach v of local ed_var {
 {
 *<_empstat_>
 	gen byte 		empstat=.
-	replace 		empstat=1 	if c19pclas==0 | c19pclas==1 | c19pclas==2 | c19pclas==5
-	replace 		empstat=2 	if c19pclas==6
-	replace 		empstat=3	if c19pclas==4
-	replace 		empstat=4 	if c19pclas==3
+	replace 		empstat=1 	if c19_pclass==0 | c19_pclass==1 | c19_pclass==2 | c19_pclass==5
+	replace 		empstat=2 	if c19_pclass==6
+	replace 		empstat=3	if c19_pclass==4
+	replace 		empstat=4 	if c19_pclass==3
 	replace 		empstat=. 	if lstatus!=1 	// includes universe restriction
 	label var 		empstat 	"Employment status during past week primary job 7 day recall"
 	la de 			lblempstat 	1 "Paid employee" ///
@@ -968,8 +972,8 @@ foreach v of local ed_var {
 
 *<_ocusec_>
 	gen byte 		ocusec = .
-	replace 		ocusec = 1 	if c19pclas == 2
-	replace 		ocusec = 2 	if inlist(c19pclas, 0, 1, 3, 4, 5, 6)
+	replace 		ocusec = 1 	if c19_pclass == 2
+	replace 		ocusec = 2 	if inlist(c19_pclass, 0, 1, 3, 4, 5, 6)
 
 	label var 		ocusec 		"Sector of activity primary job 7 day recall"
 	la de 			lblocusec 	1 "Public Sector, Central Government, Army" ///
@@ -987,6 +991,11 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_>
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary */
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary */
+
 	loc matchvar   	c18_pkb
 	loc n 			1
 
@@ -999,44 +1008,57 @@ foreach v of local ed_var {
 			tostring industry_orig	///						// make the numeric vars strings
 				, generate(industry_orig_str) ///			// gen a variable with this prefix
 				force //
+
+
 		}
 
 
 	// merge sub-module with isic key
 
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
+	gen class = `matchvar'
+	tostring 	class ///
+				, format(`"%04.0f"') replace
+
 
 	merge 		m:1 ///
-				psic_2dig ///
+				class ///
 				using `isic_key' ///
 				, generate(isic_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4	isic4_`n'
+	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	tab 		isic_merge_`n' 		if `matchvar' != .
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+
+	gen 		industrycat_isic = isic4_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		class 				// no longer needed, maintained in matchvar
+
+
+	*// industrycat_isic already generated above in submodule
+	label var 		industrycat_isic "ISIC code of primary job 7 day recall"
+
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
 	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	replace 		industrycat10=1 	if c18_pkb >= 100 	& c18_pkb <= 399	// "Agriculture, Forestry, Fishing" coded to "Agriculture"
+	replace 		industrycat10=2 	if c18_pkb >= 500 	& c18_pkb <= 999	// "Mining and Quarrying" coded to "Mining"
+	replace 		industrycat10=3 	if c18_pkb >= 1000 	& c18_pkb <= 3399 	// "Manufacturing" coded to "Manufacturing"
+	replace 		industrycat10=4 	if c18_pkb >= 3500 	& c18_pkb <= 3900	// "Water supply, sewerage, etc" coded to "Public Utiltiy"
+	replace 		industrycat10=5 	if c18_pkb >= 4100 	& c18_pkb <= 4399	// "Construction" coded to "Construction"
+	replace 		industrycat10=6 	if c18_pkb >= 4500 	& c18_pkb <= 4799	// "Wholesale/retail, repair of vehicles" to "Commerce"
+	replace 		industrycat10=7 	if c18_pkb >= 4900 	& c18_pkb <= 5399	// "Transport+storage" to "Transport". UN codes include storage
+	replace 		industrycat10=6 	if c18_pkb >= 5500 	& c18_pkb <= 5699	// "Accommodation+Food" to "Commerce"
+	replace 		industrycat10=7 	if c18_pkb >= 5800 	& c18_pkb <= 6399	// "Information+communication" to "Transport/Communication"
+	replace 		industrycat10=8 	if c18_pkb >= 6400 	& c18_pkb <= 8299	// "Misc Business Services" to "Business Services"
+	replace 		industrycat10=9 	if c18_pkb >= 8400 	& c18_pkb <= 8499	// "public administration/defense" to "public administration"
+	replace 		industrycat10=10	if c18_pkb >= 8500 	& c18_pkb <= 9950	// "Other services" including direct education to "other"
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1061,7 +1083,7 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_>
-	gen 			occup_orig = c16_proc
+	gen 			occup_orig = c16_procc
 	label var 		occup_orig "Original occupation record primary job 7 day recall"
 	replace 		occup_orig=. if lstatus!=1 			// restrict universe to employed only
 	replace 		occup_orig=. if age < minlaborage	// restrict universe to working age
@@ -1069,7 +1091,9 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-	loc matchvar   	c16_proc
+* in 2013, raw variable is numeric, 4-digits, but since there is no provided PSOC to ISCO
+* conversion, at 4 digits, substring to 2 and match at 2
+	loc matchvar   	c16_procc
 	loc n 			1
 
 	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1086,9 +1110,11 @@ foreach v of local ed_var {
 
 	// merge sub-module with isco key
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
+	gen psoc92_4dig = `matchvar'
+	tostring 	psoc92_4dig ///
+				, format(`"%04.0f"') replace
+
+	gen psoc92  = substr(psoc92_4dig, 1,2)
 
 	merge 		m:1 ///
 				psoc92 ///
@@ -1107,11 +1133,13 @@ foreach v of local ed_var {
 
 
 *<_occup_>
+
+
 	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	gen byte occup=floor(c16_procc/1000)		// this handles most of recoding automatically.
+	recode occup 0 = 10	if 	c16_procc<=129 	// recode "armed forces" to appropriate label
+	recode occup 0 = 99	if 	(c16_procc == 930) // recode "Not classifiable occupations"
+
 
 	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
 	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
@@ -1146,7 +1174,7 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_>
-	gen 			double wage_no_compen = c27_pbsc
+	gen 			double wage_no_compen = c27_pbasic
 	replace 		wage_no_compen = . if 	wage_no_compen == 99999
 	label var 		wage_no_compen "Last wage payment primary job 7 day recall"
 *</_wage_no_compen_>
@@ -1173,7 +1201,7 @@ foreach v of local ed_var {
 
 
 *<_whours_>
-	gen whours 		= c22_phrs
+	gen whours 		= c22_phours
 	label var whours "Hours of work in last week primary job 7 day recall"
     replace 		whours = 84 	if whours > 84 & whours != . 	// replace unrealistic work weeks
 *</_whours_>
@@ -1247,9 +1275,6 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2010 has no secondary job information.
-*/
 
 {
 *<_empstat_2_>
@@ -1273,6 +1298,9 @@ foreach v of local ed_var {
 
 
 *<_industrycat_isic_2_>
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary */
+
 	loc matchvar   	j03_okb
 	loc n 			2
 
@@ -1281,49 +1309,65 @@ foreach v of local ed_var {
 	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
 
 		if (`len' == 1) {
-															// run this if == 1 (ie, if industry_orig is numeric)
+															// run this if == 1 (ie, if industry_orig_2 is numeric)
 			tostring industry_orig_2	///						// make the numeric vars strings
 				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
 				force //
+
+
 		}
 
 
 	// merge sub-module with isic key
 
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
+	gen class = `matchvar'
+	tostring 	class ///
+				, format(`"%04.0f"') replace
+
 
 	merge 		m:1 ///
-				psic_2dig ///
+				class ///
 				using `isic_key' ///
 				, generate(isic_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4	isic4_`n'
+	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	tab 		isic_merge_`n' 		if `matchvar' != .
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+
+	gen 		industrycat_isic_2 = isic4_`n'  	// the string variable becomes industrycat_isic
+
+	drop 		class 				// no longer needed, maintained in matchvar
+
+
+	*// industrycat_isic already generated above in submodule
+	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+
+
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
 	gen byte 		industrycat10_2 = .
 
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
+
+	replace 		industrycat10_2=1 	if j03_okb >= 100 	& j03_okb <= 399	// "Agriculture, Forestry, Fishing" coded to "Agriculture"
+	replace 		industrycat10_2=2 	if j03_okb >= 500 	& j03_okb <= 999	// "Mining and Quarrying" coded to "Mining"
+	replace 		industrycat10_2=3 	if j03_okb >= 1000 	& j03_okb <= 3399 	// "Manufacturing" coded to "Manufacturing"
+	replace 		industrycat10_2=4 	if j03_okb >= 3500 	& j03_okb <= 3900	// "Water supply, sewerage, etc" coded to "Public Utiltiy"
+	replace 		industrycat10_2=5 	if j03_okb >= 4100 	& j03_okb <= 4399	// "Construction" coded to "Construction"
+	replace 		industrycat10_2=6 	if j03_okb >= 4500 	& j03_okb <= 4799	// "Wholesale/retail, repair of vehicles" to "Commerce"
+	replace 		industrycat10_2=7 	if j03_okb >= 4900 	& j03_okb <= 5399	// "Transport+storage" to "Transport". UN codes include storage
+	replace 		industrycat10_2=6 	if j03_okb >= 5500 	& j03_okb <= 5699	// "Accommodation+Food" to "Commerce"
+	replace 		industrycat10_2=7 	if j03_okb >= 5800 	& j03_okb <= 6399	// "Information+communication" to "Transport/Communication"
+	replace 		industrycat10_2=8 	if j03_okb >= 6400 	& j03_okb <= 8299	// "Misc Business Services" to "Business Services"
+	replace 		industrycat10_2=9 	if j03_okb >= 8400 	& j03_okb <= 8499	// "public administration/defense" to "public administration"
+	replace 		industrycat10_2=10	if j03_okb >= 8500 	& j03_okb <= 9950	// "Other services" including direct education to "other"
+
 
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
@@ -1339,13 +1383,13 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_2_>
-	gen 			occup_orig_2 = j02_otoc
+	gen 			occup_orig_2 = j02_otocc
 	label var 		occup_orig_2 "Original occupation record secondary job 7 day recall"
 *</_occup_orig_2_>
 
 
 *<_occup_isco_2_>
-	loc matchvar   	j02_otoc
+	loc matchvar   	j02_otocc
 	loc n 			2
 
 	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
@@ -1390,10 +1434,10 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
-							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+	gen byte 		occup_2=floor(j02_otocc/1000)		// this handles most of recoding automatically.
+	recode 			occup_2 0 = 10	if 	j02_otocc<=129 	// recode "armed forces" to appropriate label
+	recode 			occup_2 0 = 99	if 	(j02_otocc == 930) // recode "Not classifiable occupations"
+
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup
@@ -1401,14 +1445,14 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen 			double wage_no_compen_2 = c36_obic
+	gen 			double wage_no_compen_2 = j07_obasic
 	replace 		wage_no_compen_2 = . if wage_no_compen_2 == 99999
 	label var 		wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obis
+	gen byte 		unitwage_2 = j06_obasis
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly
@@ -1421,7 +1465,7 @@ foreach v of local ed_var {
 
 
 *<_whours_2_>
-	gen 			whours_2 = j05_ohrs
+	gen 			whours_2 = j05_ohours
 	label var 		whours_2 "Hours of work in last week secondary job 7 day recall"
 *</_whours_2_>
 

--- a/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v03_A_GLD/Programs/PHL_2014_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2014_LFS/PHL_2014_LFS_v01_M_v03_A_GLD/Programs/PHL_2014_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2014_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,10 +13,10 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2001 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2014] </_Data collection from_>
+<_Data collection to_>			[10/2014] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
@@ -30,13 +30,14 @@
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
 <_ISCO Version_>				ISCO 88 </_ISCO Version_>
 <_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-24] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2014			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,7 +80,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
@@ -89,21 +90,24 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	local 	weightvar 	fwgt // final weightvar
 
 
+
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFS JAN2014.dta"'
+	local round2 `"`stata'\LFS APR2014.dta"'
+	local round3 `"`stata'\LFS JUL2014.dta"'
+	local round4 `"`stata'\LFS OCT2014.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig_updated.dta"'
 	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
+	
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
+	
 ** VALUES
 	local n_round 	4			// numer of survey rounds
 
@@ -118,7 +122,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
 		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		, clear surveys(JAN2014 APR2014 JUL2014 OCT2014) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -163,7 +167,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +185,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -229,10 +233,6 @@ replace int_month = 10 	if round == 4
 
 </_hhid_note> */
 ** HOUSEHOLD IDENTIFICATION NUMBER
-
-** HOUSEHOLD IDENTIFICATION NUMBER
-
-
 	loc idhvars 	hhnum   							// store idh vars in local
 
 
@@ -303,7 +303,6 @@ replace int_month = 10 	if round == 4
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
 
-
 	gen  hhid = idh  									// make hhid from idh in module
 	label var hhid "Household ID"
 
@@ -320,9 +319,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
+	rename 		weight weight_orig
 	gen 		weight = fwgt / 4
 	label 		var weight "Household sampling weight"
+
+	/*there is one household with an odd household ID and no weight (total 1 observation). Will drop*/
+	drop 		if weight == .
+	assert 		r(N_drop) == 1  	// ensure only 1 obs was dropped
 *</_weight_>
 
 
@@ -572,7 +575,7 @@ replace int_month = 10 	if round == 4
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+		gen byte 		marital = c08_ms
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -744,15 +747,17 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte educat7=.
 
+	replace educat7=1 if j12c09_grade==0 | j12c09_grade == 10 	// "No education" and "Preschool" -> "No Education"
+	replace educat7=2 if j12c09_grade>=210 &  j12c09_grade<=260	// Grades 1-7 to "Primary Incomplete"
+	replace educat7=3 if j12c09_grade==280						// "Elementary Graduate" to "Primary Complete"
+	replace educat7=4 if j12c09_grade>=310 &  j12c09_grade<=340 	// First-Fourth year in High school -> "secondary incomplete"
+	replace educat7=5 if j12c09_grade==350						// "High school graduate" -> "secondary complete"
+	replace educat7=6 if j12c09_grade>=410 &  j12c09_grade<=501 	// Post secondary + Basic Programs -> "Higher secondary not uni"
+	replace educat7=6 if j12c09_grade>=502 & 	j12c09_grade<=699	// Basic Program degrees to "Higher secondary not uni"
+	replace educat7=7 if j12c09_grade>= 810 & j12c09_grade <= . // all labelled uni levels Advanced Degree" -> "University"
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +798,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = j12c09_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -1016,27 +1021,29 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
 	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	replace 		industrycat10=1 if (c18_pkb>=1& c18_pkb<=4)		// to Agriculture
+	replace 		industrycat10=2 if (c18_pkb>=5 & c18_pkb<=9)		// to Mining
+	replace 		industrycat10=3 if (c18_pkb>=10 & c18_pkb<=33)	// to Manufacturing
+	replace 		industrycat10=4 if (c18_pkb>=35 & c18_pkb<=39)	// to Public utility
+	replace 		industrycat10=5 if (c18_pkb>=41 &  c18_pkb<=43)	// to Construction
+	replace 		industrycat10=6 if (c18_pkb>=45 & c18_pkb<=47) | (c18_pkb >= 55 & c18_pkb <= 56)	// to Commerce
+	replace 		industrycat10=7 if (c18_pkb>=49 & c18_pkb<=53)| (c18_pkb>=58 & c18_pkb<=63) // to Transport/coms
+	replace 		industrycat10=8 if (c18_pkb>=64 & c18_pkb<=82) 	// to financial/business services
+	replace 		industrycat10=9 if (c18_pkb==84) 				// to public administration
+	replace 		industrycat10=10 if  (c18_pkb>=91 & c18_pkb<=99) // to other
+	replace 		industrycat10=10 if industrycat10==. & c18_pkb!=.
+
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1107,11 +1114,14 @@ foreach v of local ed_var {
 
 
 *<_occup_>
+	* in 2014, raw variable is numeric 2 digits only
+
 	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	gen byte occup=floor(c16_proc/10)		// this handles most of recoding automatically.
+	recode occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
+	recode occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
+							| (c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+
 
 	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
 	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
@@ -1247,9 +1257,7 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2010 has no secondary job information.
-*/
+
 
 {
 *<_empstat_2_>
@@ -1302,9 +1310,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic_2 = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
@@ -1314,16 +1322,20 @@ foreach v of local ed_var {
 *<_industrycat10_2_>
 	gen byte 		industrycat10_2 = .
 
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
+
+	replace 		industrycat10_2=1 if (j03_okb>=1& j03_okb<=4)		// to Agriculture
+	replace 		industrycat10_2=2 if (j03_okb>=5 & j03_okb<=9)		// to Mining
+	replace 		industrycat10_2=3 if (j03_okb>=10 & j03_okb<=33)	// to Manufacturing
+	replace 		industrycat10_2=4 if (j03_okb>=35 & j03_okb<=39)	// to Public utility
+	replace 		industrycat10_2=5 if (j03_okb>=41 &  j03_okb<=43)	// to Construction
+	replace 		industrycat10_2=6 if (j03_okb>=45 & j03_okb<=47) | (j03_okb>= 55 & j03_okb <= 56)	// to Commerce
+	replace 		industrycat10_2=7 if (j03_okb>=49 & j03_okb<=53)| (j03_okb>=58 & j03_okb<=63) // to Transport/coms
+	replace 		industrycat10_2=8 if (j03_okb>=64 & j03_okb<=82) 	// to financial/business services
+	replace 		industrycat10_2=9 if (j03_okb==84) 				// to public administration
+	replace 		industrycat10_2=10 if  (j03_okb>=91 & j03_okb<=99) // to other
+	replace 		industrycat10_2=10 if industrycat10_2==. & j03_okb!=.
+
+
 
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
@@ -1390,10 +1402,11 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
+	gen byte		occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
+	recode 			occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
+	recode 			occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
 							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup

--- a/GLD/PHL/PHL_2015_LFS/PHL_2015_LFS_v01_M_v03_A_GLD/Programs/PHL_2015_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2015_LFS/PHL_2015_LFS_v01_M_v03_A_GLD/Programs/PHL_2015_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2015_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,10 +13,10 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2015 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2015] </_Data collection from_>
+<_Data collection to_>			[10/2015] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
@@ -30,13 +30,14 @@
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
 <_ISCO Version_>				ISCO 88 </_ISCO Version_>
 <_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-26] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2015			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,30 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	pwgt // final weightvar
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFS JAN2015.dta"'
+	local round2 `"`stata'\LFS APR2015.dta"'
+	local round3 `"`stata'\LFS JUL2015.dta"'
+	local round4 `"`stata'\LFS OCT2015.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig_updated.dta"'
 	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -118,7 +119,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
 		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		, clear surveys(JAN2015 APR2015 JUL2015 OCT2015) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -163,7 +164,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +182,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -229,9 +230,6 @@ replace int_month = 10 	if round == 4
 
 </_hhid_note> */
 ** HOUSEHOLD IDENTIFICATION NUMBER
-
-** HOUSEHOLD IDENTIFICATION NUMBER
-
 
 	loc idhvars 	hhnum   							// store idh vars in local
 
@@ -303,7 +301,6 @@ replace int_month = 10 	if round == 4
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
 
-
 	gen  hhid = idh  									// make hhid from idh in module
 	label var hhid "Household ID"
 
@@ -320,8 +317,8 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	*rename 		weight weight_orig
+	gen 		weight = pwgt / 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
@@ -744,15 +741,17 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte educat7=.
 
+	replace educat7=1 if j12c09_grade==0 | j12c09_grade == 10 	// "No education" and "Preschool" -> "No Education"
+	replace educat7=2 if j12c09_grade>=210 &  j12c09_grade<=260	// Grades 1-7 to "Primary Incomplete"
+	replace educat7=3 if j12c09_grade==280						// "Elementary Graduate" to "Primary Complete"
+	replace educat7=4 if j12c09_grade>=310 &  j12c09_grade<=340 	// First-Fourth year in High school -> "secondary incomplete"
+	replace educat7=5 if j12c09_grade==350						// "High school graduate" -> "secondary complete"
+	replace educat7=6 if j12c09_grade>=410 &  j12c09_grade<=501 	// Post secondary + Basic Programs -> "Higher secondary not uni"
+	replace educat7=6 if j12c09_grade>=502 & 	j12c09_grade<=699	// Basic Program degrees to "Higher secondary not uni"
+	replace educat7=7 if j12c09_grade>= 810 & j12c09_grade <= . // all labelled uni levels Advanced Degree" -> "University"
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +792,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = j12c09_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -1016,27 +1015,29 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
 	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	replace 		industrycat10=1 if (c18_pkb>=1& c18_pkb<=4)		// to Agriculture
+	replace 		industrycat10=2 if (c18_pkb>=5 & c18_pkb<=9)		// to Mining
+	replace 		industrycat10=3 if (c18_pkb>=10 & c18_pkb<=33)	// to Manufacturing
+	replace 		industrycat10=4 if (c18_pkb>=35 & c18_pkb<=39)	// to Public utility
+	replace 		industrycat10=5 if (c18_pkb>=41 &  c18_pkb<=43)	// to Construction
+	replace 		industrycat10=6 if (c18_pkb>=45 & c18_pkb<=47) | (c18_pkb >= 55 & c18_pkb <= 56)	// to Commerce
+	replace 		industrycat10=7 if (c18_pkb>=49 & c18_pkb<=53)| (c18_pkb>=58 & c18_pkb<=63) // to Transport/coms
+	replace 		industrycat10=8 if (c18_pkb>=64 & c18_pkb<=82) 	// to financial/business services
+	replace 		industrycat10=9 if (c18_pkb==84) 				// to public administration
+	replace 		industrycat10=10 if  (c18_pkb>=91 & c18_pkb<=99) // to other
+	replace 		industrycat10=10 if industrycat10==. & c18_pkb!=.
+
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1107,11 +1108,14 @@ foreach v of local ed_var {
 
 
 *<_occup_>
+	* in 2015, raw variable is numeric 2 digits only
+
 	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	gen byte occup=floor(c16_proc/10)		// this handles most of recoding automatically.
+	recode occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
+	recode occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
+							| (c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+
 
 	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
 	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
@@ -1247,9 +1251,7 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2010 has no secondary job information.
-*/
+
 
 {
 *<_empstat_2_>
@@ -1302,9 +1304,9 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic_2 = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
@@ -1314,16 +1316,20 @@ foreach v of local ed_var {
 *<_industrycat10_2_>
 	gen byte 		industrycat10_2 = .
 
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
+
+	replace 		industrycat10_2=1 if (j03_okb>=1& j03_okb<=4)		// to Agriculture
+	replace 		industrycat10_2=2 if (j03_okb>=5 & j03_okb<=9)		// to Mining
+	replace 		industrycat10_2=3 if (j03_okb>=10 & j03_okb<=33)	// to Manufacturing
+	replace 		industrycat10_2=4 if (j03_okb>=35 & j03_okb<=39)	// to Public utility
+	replace 		industrycat10_2=5 if (j03_okb>=41 &  j03_okb<=43)	// to Construction
+	replace 		industrycat10_2=6 if (j03_okb>=45 & j03_okb<=47) | (j03_okb>= 55 & j03_okb <= 56)	// to Commerce
+	replace 		industrycat10_2=7 if (j03_okb>=49 & j03_okb<=53)| (j03_okb>=58 & j03_okb<=63) // to Transport/coms
+	replace 		industrycat10_2=8 if (j03_okb>=64 & j03_okb<=82) 	// to financial/business services
+	replace 		industrycat10_2=9 if (j03_okb==84) 				// to public administration
+	replace 		industrycat10_2=10 if  (j03_okb>=91 & j03_okb<=99) // to other
+	replace 		industrycat10_2=10 if industrycat10_2==. & j03_okb!=.
+
+
 
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
@@ -1390,10 +1396,11 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
+	gen byte		occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
+	recode 			occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
+	recode 			occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
 							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v03_A_GLD/Programs/PHL_2016_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v03_A_GLD/Programs/PHL_2016_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2016_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,30 +13,31 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2016 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2016] </_Data collection from_>
+<_Data collection to_>			[10/2016] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
-<_Sampling method_> 			Geographic regions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
-<_Geographic coverage_> 		1st-level Subdivision (Region) </_Geographic coverage_>
+<_Sampling method_> 			Geographic pufregions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
+<_Geographic coverage_> 		1st-level Subdivision (pufregion) </_Geographic coverage_>
 <_Currency_> 					[Currency used for wages] </_Currency_>
 
 -----------------------------------------------------------------------
 
 <_ICLS Version_>				ICLS-13 </_ICLS Version_>
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
-<_ISCO Version_>				ISCO 88 </_ISCO Version_>
-<_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISCO Version_>				ISCO 08 </_ISCO Version_>
+<_OCCUP National_>				PSOC 12 </_OCCUP National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-26] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2016			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,32 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	weight // final weightvar
+
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFS JAN2016.dta"'
+	local round2 `"`stata'\LFS APR2016.dta"'
+	local round3 `"`stata'\LFS JUL2016.dta"'
+	local round4 `"`stata'\LFS OCT2016.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig_updated.dta"'
+	local isco_key92 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isco_key12 	 `"`stata'\PHL_PSOC_ISCO_12_key_2dig.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -118,7 +121,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
 		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		, clear surveys(JAN2016 APR2016 JUL2016 OCT2016) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -157,13 +160,13 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isco_version_>
-	gen isco_version = "isco_1988"
+	gen isco_version = "isco_2008"
 	label var isco_version "Version of ISCO used"
 *</_isco_version_>
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +184,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -199,7 +202,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_int_month_>
-	gen  int_month = svymo
+	gen  int_month = pufsvymo
 	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
 	label value int_month lblint_month
 	label var int_month "Month of the interview"
@@ -229,11 +232,7 @@ replace int_month = 10 	if round == 4
 
 </_hhid_note> */
 ** HOUSEHOLD IDENTIFICATION NUMBER
-
-** HOUSEHOLD IDENTIFICATION NUMBER
-
-
-	loc idhvars 	hhnum   							// store idh vars in local
+	loc idhvars 	pufhhnum   							// store idh vars in local
 
 
 	ds `idhvars',  	has(type numeric)					// filter out numeric variables in local
@@ -277,7 +276,7 @@ replace int_month = 10 	if round == 4
 	* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
 	*	so, not following processing for sorting numeric/non-numeric variables.
 
-	loc idpvars 	c101_lno 							// store relevant idp vars in local
+	loc idpvars 	pufc01_lno 							// store relevant idp vars in local
 	ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
 	loc rlist 		= r(varlist)						// store numeric vars in local
 
@@ -303,7 +302,6 @@ replace int_month = 10 	if round == 4
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
 
-
 	gen  hhid = idh  									// make hhid from idh in module
 	label var hhid "Household ID"
 
@@ -320,15 +318,14 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	rename 		`weightvar'	weight_orig
+	gen 		weight = weight_orig/ 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
 
 *<_psu_>
-	rename 		psu psu_orig
-	gen 		psu = psu_orig
+	gen 		psu = pufpsu
 	label 		var psu "Primary sampling units"
 *</_psu_>
 
@@ -367,7 +364,7 @@ replace int_month = 10 	if round == 4
 
 *<_urban_>
 	gen byte 		urban = .
-	replace 		urban = urb2k70
+	replace 		urban = pufurb2k10
 	recode 			urban (2 = 0) 		// change rural=2 to rural=0
 	label var 		urban "Location is urban"
 	la de 			lblurban 1 "Urban" 0 "Rural"
@@ -381,7 +378,7 @@ replace int_month = 10 	if round == 4
 	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
 
 </_subnatid1> */
-	gen byte 		subnatid1 = reg
+	gen byte 		subnatid1 = pufreg
 	label de 		lblsubnatid1 	///
 					 1   "1 - Ilocos"			///
 					 2	 "2 - Cagayan Valley"	///
@@ -395,12 +392,12 @@ replace int_month = 10 	if round == 4
 					 10  "10 - Northern Mindanao"	///
 					 11  "11 - Davao"	///
 					 12  "12 - Soccsksargen"		///
-					 13  "13 - National Capital Region"				///
-					 14  "14 - Cordillera Administrative Region"		///
-					 15  "15 - Autonomous Region of Muslim Mindanao"	///
+					 13  "13 - National Capital pufregion"				///
+					 14  "14 - Cordillera Administrative pufregion"		///
+					 15  "15 - Autonomous pufregion of Muslim Mindanao"	///
 					 16  "16 - Caraga" ///
 					 /// value 17 exists only in raw data, not in recoded version
-					 18  "18 - Negros Island Region" /// this region appears occasionally in data
+					 18  "18 - Negros Island pufregion" /// this pufregion appears occasionally in data
 				 	 							///
 				 	 41	 "41 - Calabarzon"	/// formerly part of Southern Tagalog
 				 	 42  "42 - Mimaropa"		// formerly part of Southern Tagalog
@@ -511,7 +508,7 @@ replace int_month = 10 	if round == 4
 
 *<_hsize_>
 	sort hhid
-	by hhid: egen hsize= count(c05_rel <= 8 | c05_rel == 11) // includes non-family members, not boarders or domestic workers.
+	by hhid: egen hsize= count(pufc03_rel <= 8 | pufc03_rel == 11) // includes non-family members, not boarders or domestic workers.
 	label var 	hsize "Household size"
 
 	* check
@@ -522,14 +519,14 @@ replace int_month = 10 	if round == 4
 
 
 *<_age_>
-	gen 		age = c07_age
+	gen 		age = pufc05_age
 	replace 	age	= 98 	if age>=98 & age!=.
 	label var 	age "Individual age"
 *</_age_>
 
 
 *<_male_>
-	gen 		male = c06_sex
+	gen 		male = pufc04_sex
 	recode 		male (2 = 0)						// female=2 recoded to female=0
 	label var 	male "Sex - Ind is male"
 	la de 		lblmale 	1 "Male" 0 "Female"
@@ -539,7 +536,7 @@ replace int_month = 10 	if round == 4
 
 *<_relationharm_>
 	gen 		relationharm = .
-	replace 	relationharm = c05_rel
+	replace 	relationharm = pufc03_rel
 	recode 		relationharm (4 5 6 8  	= 5) /// siblings, children in law, grandchildren, other rel of hh head="other relatives"
 					(7 			= 4)	/// parents of hh head become "parents"
 					(9 10 11 	= 6) 	// boarders and domestic workers become "other/non-relatives"
@@ -566,13 +563,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_relationcs_>
-	gen relationcs = c05_rel
+	gen relationcs = pufc03_rel
 	label var relationcs "Relationship to the head of household - Country original"
 *</_relationcs_>
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+	gen byte 		marital = pufc06_mstat
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -717,7 +714,7 @@ label var ed_mod_age "Education module application age"
 *</_ed_mod_age_>
 
 *<_school_>
-	gen byte school= a02_csch
+	gen byte school= pufc08_cursch
 	recode school (2 = 0)		// 2 was "no", recode to 0. Keep 1=Yes same.
 	label var school "Attending school"
 	la de lblschool 0 "No" 1 "Yes"
@@ -744,15 +741,20 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte educat7=.
 
+	replace 	educat7=1 if pufc07_grade==0 | pufc07_grade == 10 	// "No education" and "Preschool" -> "No Education"
+	replace 	educat7=2 if pufc07_grade>=210 &  pufc07_grade<=260	// Grades 1-7 to "Primary Incomplete"
+	replace 	educat7=3 if pufc07_grade==280						// "Elementary Graduate" to "Primary Complete"
+	replace 	educat7=4 if pufc07_grade>=310 &  pufc07_grade<=340 	// First-Fourth year in High school -> "secondary incomplete"
+	replace 	educat7=5 if pufc07_grade==350						// "High school graduate" -> "secondary complete"
+	replace 	educat7=6 if pufc07_grade>=410 &  pufc07_grade<=501 	// Post secondary + Basic Programs -> "Higher secondary not uni"
+	replace 	educat7=6 if pufc07_grade>=502 & 	pufc07_grade<=699	// Basic Program degrees to "Higher secondary not uni"
+	replace 	educat7=7 if pufc07_grade>= 810 & pufc07_grade <= . // all labelled uni levels
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
+	* for 2016, replace educat7 == missing if the rounds/month is July or October.
+	* this is because there is not enough information for these rounds, which differ from the first two.
+	replace 	educat7 = . 	if pufsvymo == 7 | pufsvymo == 10 		// if july or october
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +795,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = pufc07_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -892,8 +894,8 @@ foreach v of local ed_var {
 *<_potential_lf_>
 	gen byte 		potential_lf = 0
 
-	replace 		potential_lf = 1 if (c37_avil == 1 & c38_lokw == 2) ///
-										| (c37_avil == 2 & c38_lokw == 1)
+	replace 		potential_lf = 1 if (pufc36_avail == 1 & pufc30_lookw == 2) ///
+										| (pufc36_avail == 2 & pufc30_lookw == 1)
 	replace 		potential_lf = . if age < minlaborage & age != .
 	replace 		potential_lf = . if lstatus != 3
 	label var 		potential_lf "Potential labour force status"
@@ -905,7 +907,7 @@ foreach v of local ed_var {
 *<_underemployment_>
 	gen byte 		underemployment = 0
 
-	replace 		underemployment = 1 if c23_pwmr == 1
+	replace 		underemployment = 1 if pufc20_pwmore == 1
 	replace 		underemployment = . if age < minlaborage & age != .
 	replace 		underemployment = . if lstatus != 1
 	label var 		underemployment "Underemployment status"
@@ -916,11 +918,11 @@ foreach v of local ed_var {
 
 *<_nlfreason_>
 	gen byte 		nlfreason= .
-	replace 		nlfreason=1 	if c42_wynt==8
-	replace 		nlfreason=2 	if c42_wynt==7
-	replace 		nlfreason=3 	if c42_wynt==6
-	replace 		nlfreason=4 	if c42_wynt==3
-	replace 		nlfreason=5 	if c42_wynt==1 | c42_wynt==2 | c42_wynt==4 | c42_wynt==5 | c42_wynt==9
+	replace 		nlfreason=1 	if pufc34_wynot==8
+	replace 		nlfreason=2 	if pufc34_wynot==7
+	replace 		nlfreason=3 	if pufc34_wynot==6
+	replace 		nlfreason=4 	if pufc34_wynot==3
+	replace 		nlfreason=5 	if pufc34_wynot==1 | pufc34_wynot==2 | pufc34_wynot==4 | pufc34_wynot==5 | pufc34_wynot==9
 	replace 		nlfreason=. 	if lstatus!=3 		// restricts universe to non-labor force
 	label var 		nlfreason "Reason not in the labor force"
 	la de 			lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
@@ -929,7 +931,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_l_>
-	gen byte 		unempldur_l=c40_wks/4.2
+	gen byte 		unempldur_l=pufc33_weeks/4.2
 	label var 		unempldur_l "Unemployment duration (months) lower bracket"
 	replace 		unempldur_l=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -937,7 +939,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_u_>
-	gen byte 		unempldur_u=c40_wks/4.2
+	gen byte 		unempldur_u=pufc33_weeks/4.2
 	label var 		unempldur_u "Unemployment duration (months) upper bracket"
 	replace 		unempldur_u=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -951,10 +953,10 @@ foreach v of local ed_var {
 {
 *<_empstat_>
 	gen byte 		empstat=.
-	replace 		empstat=1 	if c19pclas==0 | c19pclas==1 | c19pclas==2 | c19pclas==5
-	replace 		empstat=2 	if c19pclas==6
-	replace 		empstat=3	if c19pclas==4
-	replace 		empstat=4 	if c19pclas==3
+	replace 		empstat=1 	if pufc23_pclass==0 | pufc23_pclass==1 | pufc23_pclass==2 | pufc23_pclass==5
+	replace 		empstat=2 	if pufc23_pclass==6
+	replace 		empstat=3	if pufc23_pclass==4
+	replace 		empstat=4 	if pufc23_pclass==3
 	replace 		empstat=. 	if lstatus!=1 	// includes universe restriction
 	label var 		empstat 	"Employment status during past week primary job 7 day recall"
 	la de 			lblempstat 	1 "Paid employee" ///
@@ -968,8 +970,8 @@ foreach v of local ed_var {
 
 *<_ocusec_>
 	gen byte 		ocusec = .
-	replace 		ocusec = 1 	if c19pclas == 2
-	replace 		ocusec = 2 	if inlist(c19pclas, 0, 1, 3, 4, 5, 6)
+	replace 		ocusec = 1 	if pufc23_pclass == 2
+	replace 		ocusec = 2 	if inlist(pufc23_pclass, 0, 1, 3, 4, 5, 6)
 
 	label var 		ocusec 		"Sector of activity primary job 7 day recall"
 	la de 			lblocusec 	1 "Public Sector, Central Government, Army" ///
@@ -981,13 +983,13 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_>
-	gen 			industry_orig = c18_pkb
+	gen 			industry_orig = pufc16_pkb
 	label var 		industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 
 
 *<_industrycat_isic_>
-	loc matchvar   	c18_pkb
+	loc matchvar   	pufc16_pkb
 	loc n 			1
 
 	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1016,27 +1018,29 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
 	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	replace 		industrycat10=1 if (pufc16_pkb>=1& pufc16_pkb<=4)		// to Agriculture
+	replace 		industrycat10=2 if (pufc16_pkb>=5 & pufc16_pkb<=9)		// to Mining
+	replace 		industrycat10=3 if (pufc16_pkb>=10 & pufc16_pkb<=33)	// to Manufacturing
+	replace 		industrycat10=4 if (pufc16_pkb>=35 & pufc16_pkb<=39)	// to Public utility
+	replace 		industrycat10=5 if (pufc16_pkb>=41 &  pufc16_pkb<=43)	// to Construction
+	replace 		industrycat10=6 if (pufc16_pkb>=45 & pufc16_pkb<=47) | (pufc16_pkb >= 55 & pufc16_pkb <= 56)	// to Commerce
+	replace 		industrycat10=7 if (pufc16_pkb>=49 & pufc16_pkb<=53)| (pufc16_pkb>=58 & pufc16_pkb<=63) // to Transport/coms
+	replace 		industrycat10=8 if (pufc16_pkb>=64 & pufc16_pkb<=82) 	// to financial/business services
+	replace 		industrycat10=9 if (pufc16_pkb==84) 				// to public administration
+	replace 		industrycat10=10 if  (pufc16_pkb>=91 & pufc16_pkb<=99) // to other
+	replace 		industrycat10=10 if industrycat10==. & pufc16_pkb!=.
+
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1061,7 +1065,7 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_>
-	gen 			occup_orig = c16_proc
+	gen 			occup_orig = pufc14_procc
 	label var 		occup_orig "Original occupation record primary job 7 day recall"
 	replace 		occup_orig=. if lstatus!=1 			// restrict universe to employed only
 	replace 		occup_orig=. if age < minlaborage	// restrict universe to working age
@@ -1069,7 +1073,21 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-	loc matchvar   	c16_proc
+/* in 2016, raw variable is numeric, 2-digits, so typically this variable would be left as missing.
+	However, The data span two ISCO classification systems this year: January 2016/wave1 is
+	PSOC92 (ISCO-88) and starting in April/wave2, data are coded in PSOC12 (ISCO08).
+
+	Normally, a 2-digit conversion would be provided like this:
+
+	Conversion 1: convert each PSOC schema to the ISCO equivalent
+	(Wave1)	  1992 PSOC -> 1988 ISCO
+	(Wave2-4) 2012 ISCO -> 2008 ISCO
+
+	Conversion 2: convert all ISCO revisions to ISCO 2008
+
+*/
+
+	loc matchvar   	pufc14_procc
 	loc n 			1
 
 	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1080,38 +1098,91 @@ foreach v of local ed_var {
 															// run this if == 1 (ie, if occup_orig is numeric)
 			tostring occup_orig	///						// make the numeric vars strings
 				, generate(occup_orig_str) ///			// gen a variable with this prefix
-				force
+				force //
 		}
 
 
 	// merge sub-module with isco key
 
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	replace 	psic_2dig = "" 	if psic_2dig == "." 	// fix missing
+	replace 	psic_2dig = "" 	if wave == "Q1"			// ensure to only match waves 2-4
+
+	// merge with isco12 key (for waves2-4)
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isco_key12' ///
+				, generate(isco_merge12_`n') ///
+				keep(master match) // "left join"; remove obs that don't match from using
+
+				* use the 2 digit padded isco08 variable:  isco08_2dig_pad
+
+	// merge with isco92 key (for wave 1)
+	* now the missing obs in psic_2dig are those in waves 2-4 that didn't match isco12 and
+	* all obs in wave1
+
+	** create an identical variable that is only non-missing for wave1
 	gen psoc92 = `matchvar'
+
 	tostring 	psoc92 ///
 				, format(`"%02.0f"') replace
 
+	replace 	psoc92 = "" 	if psoc92 == "." 	// fix missing
+	replace 	psoc92 = "" 	if wave != "Q1"			// ensure to only match waves 2-4
+
+
 	merge 		m:1 ///
 				psoc92 ///
-				using `isco_key' ///
-				, generate(isco_merge_`n') ///
+				using `isco_key92' ///
+				, generate(isco_merge92_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
+				* use the 2 digit padded isco08 variable:  sub_major_isco08_pad
 
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
 
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco = isco88_sub_major_`n'
+	// coalese 2 variables
+	egen 		str4 occup_isco_`n' = rowfirst(isco08_2dig_pad sub_major_isco08_pad)
+
+	drop 		psoc92 psic_2dig			// drop both; no longer needed, maintained in matchvar
+
+	gen 		occup_isco = occup_isco_`n'
 	label var 	occup_isco "ISCO code of primary job 7 day recall"
+
 
 *</_occup_isco_>
 
 
 *<_occup_>
-	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	* in 2016, raw variable is numeric 2 digits only
+	* generate empty variable
+	gen byte occup = .
+
+	* replace conditionally based on January round (1992 PSOC)
+	replace 		occup=floor(pufc14_procc/10)		///
+					if 	round == 1
+
+	recode 			occup 0 = 10		///
+					if 	pufc14_procc==1 	/// recode "armed forces" to appropriate label
+					& 	round == 1
+
+	recode 			occup 0 = 99		///
+					if 	(pufc14_procc>=2 & pufc14_procc <=9) ///
+					| (pufc14_procc >=94 & pufc14_procc <= 99) /// recode "Not classifiable occupations"
+					& round == 1
+
+
+	* replace conditionally based on April, July, October rounds (2012 PSOC)
+	replace			occup=floor(pufc14_procc/10)							///
+					if (round == 4 | round == 7 | round == 10)
+
+	recode 			occup 0 = 10									///
+					if 	(pufc14_procc >=1 & pufc14_procc <=3)				/// recode "armed forces" to appropriate label
+					& 	(round == 4 | round == 7 | round == 10)
+
+
 
 	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
 	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
@@ -1134,7 +1205,6 @@ foreach v of local ed_var {
 *</_occup_>
 
 
-*<_occup_skill_>
 	gen occup_skill=occup
 	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
 	replace occup_skill=. if lstatus!=1
@@ -1146,7 +1216,7 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_>
-	gen 			double wage_no_compen = c27_pbsc
+	gen 			double wage_no_compen = pufc25_pbasic
 	replace 		wage_no_compen = . if 	wage_no_compen == 99999
 	label var 		wage_no_compen "Last wage payment primary job 7 day recall"
 *</_wage_no_compen_>
@@ -1173,7 +1243,7 @@ foreach v of local ed_var {
 
 
 *<_whours_>
-	gen whours 		= c22_phrs
+	gen whours 		= pufc19_phours
 	label var whours "Hours of work in last week primary job 7 day recall"
     replace 		whours = 84 	if whours > 84 & whours != . 	// replace unrealistic work weeks
 *</_whours_>
@@ -1247,9 +1317,8 @@ foreach v of local ed_var {
 
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
-/*
-2010 has no secondary job information.
-*/
+* secondary job not available for all rounds; in some rounds the data are only encoded as "previous quarter" job.
+* Will simply leave secondary job as missing.
 
 {
 *<_empstat_2_>
@@ -1267,64 +1336,24 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_2_>
-	gen 			industry_orig_2 = j03_okb
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			industry_orig_2 = .
 	label var 		industry_orig_2 "Original survey industry code, secondary job 7 day recall"
 *</_industry_orig_2_>
 
 
 *<_industrycat_isic_2_>
-	loc matchvar   	j03_okb
-	loc n 			2
-
-	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc isicvar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if industry_orig is numeric)
-			tostring industry_orig_2	///						// make the numeric vars strings
-				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
-				force //
-		}
+	gen 			industrycat_isic_2 = .
+	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 
 
-	// merge sub-module with isic key
-
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psic_2dig ///
-				using `isic_key' ///
-				, generate(isic_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-				* the string variable in isic4 will is industrycat_isic
-
-	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
-
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
-
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
-	gen byte 		industrycat10_2 = .
-
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
-
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+	gen byte 			industrycat10_2 = .
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
 *</_industrycat10_2_>
@@ -1339,45 +1368,18 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_2_>
-	gen 			occup_orig_2 = j02_otoc
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			occup_orig_2 = .
 	label var 		occup_orig_2 "Original occupation record secondary job 7 day recall"
 *</_occup_orig_2_>
 
 
 *<_occup_isco_2_>
-	loc matchvar   	j02_otoc
-	loc n 			2
-
-	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc iscovar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if occup_orig is numeric)
-			tostring occup_orig_2	///						// make the numeric vars strings
-				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
-				force
-		}
-
-
-	// merge sub-module with isco key
-
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psoc92 ///
-				using `isco_key' ///
-				, generate(isco_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-
-
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
-
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco_2 = isco88_sub_major_`n'
+	gen occup_isco_2 = ""
 	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
+
+
 *</_occup_isco_2_>
 
 
@@ -1390,10 +1392,9 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
-							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen byte occup_2 = .
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup
@@ -1401,14 +1402,14 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen 			double wage_no_compen_2 = c36_obic
+	gen 			double wage_no_compen_2 = .
 	replace 		wage_no_compen_2 = . if wage_no_compen_2 == 99999
 	label var 		wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obis
+	gen byte 		unitwage_2 = .
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly
@@ -1421,7 +1422,7 @@ foreach v of local ed_var {
 
 
 *<_whours_2_>
-	gen 			whours_2 = j05_ohrs
+	gen 			whours_2 = .
 	label var 		whours_2 "Hours of work in last week secondary job 7 day recall"
 *</_whours_2_>
 

--- a/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v03_A_GLD/Programs/PHL_2016_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2016_LFS/PHL_2016_LFS_v01_M_v03_A_GLD/Programs/PHL_2016_LFS_v01_M_v03_A_GLD_ALL.do
@@ -1205,6 +1205,7 @@ foreach v of local ed_var {
 *</_occup_>
 
 
+*<_occup_skill_>
 	gen occup_skill=occup
 	recode occup_skill (1/3=3) (4/8=2) (9=1) (0 5=.)
 	replace occup_skill=. if lstatus!=1

--- a/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v03_A_GLD/Programs/PHL_2017_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2017_LFS/PHL_2017_LFS_v01_M_v03_A_GLD/Programs/PHL_2017_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2017_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,30 +13,31 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2017 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2017] </_Data collection from_>
+<_Data collection to_>			[10/2017] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
-<_Sampling method_> 			Geographic regions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
-<_Geographic coverage_> 		1st-level Subdivision (Region) </_Geographic coverage_>
+<_Sampling method_> 			Geographic pufregions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
+<_Geographic coverage_> 		1st-level Subdivision (pufregion) </_Geographic coverage_>
 <_Currency_> 					[Currency used for wages] </_Currency_>
 
 -----------------------------------------------------------------------
 
 <_ICLS Version_>				ICLS-13 </_ICLS Version_>
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
-<_ISCO Version_>				ISCO 88 </_ISCO Version_>
-<_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISCO Version_>				ISCO 08 </_ISCO Version_>
+<_OCCUP National_>				PSOC 12 </_OCCUP National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-26] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2017			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,35 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	pufpwgtprv // final weightvar
+
+** LOG FILE
+	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFS JAN2017.dta"'
+	local round2 `"`stata'\LFS APR2017.dta"'
+	local round3 `"`stata'\LFS JUL2017.dta"'
+	local round4 `"`stata'\LFS OCT2017.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key.dta"'
+	local isic_key2dig 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig_updated.dta"'
+	local isco_key2dig 	 `"`stata'\PHL_PSOC_ISCO_12_key_2dig.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -117,8 +123,8 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
-		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN-S.xlsx"' /// output just created above
+		, clear surveys(JAN2017 APR2017 JUL2017 OCT2017) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -157,13 +163,13 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isco_version_>
-	gen isco_version = "isco_1988"
+	gen isco_version = "isco_2008"
 	label var isco_version "Version of ISCO used"
 *</_isco_version_>
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +187,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -199,7 +205,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_int_month_>
-	gen  int_month = svymo
+	gen  int_month = pufsvymo
 	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
 	label value int_month lblint_month
 	label var int_month "Month of the interview"
@@ -221,20 +227,24 @@ replace int_month = 10 	if round == 4
 	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
 	002, ..., 160.
 
-	Since individual Household ID variables were not always provided for the Philippines, yet the household
-	line number variables were provided, it was possible to approximate the household groupings by other variables.
+	Since individual Household ID variables were not always pufprvided for the Philippines, yet the household
+	line number variables were pufprvided, it was possible to approximate the household groupings by other variables.
 	However, this process was not perfectly clean, so checks for duplicates were needed. Please refer to the
 	"Household_IDs.md" in Guides and Documentation for additional explanation. The two variables, hhid and pid
 	will be produced in conjunction, the labelled in the html brackets.
 
 </_hhid_note> */
 ** HOUSEHOLD IDENTIFICATION NUMBER
+/*This part is the only variable that has to be coded conditional by round. This means that we'll have to split the dataset up by round
+ 	and create tempfiles before appending back together. Not ideal but it avoids having separate scripts for each round. */
 
-** HOUSEHOLD IDENTIFICATION NUMBER
+	tempfile 		partA	partB						// declare tempfiles, Part A is first 3 rounds, Part B is round 4/october
 
+	preserve   											// preserve the original appended dataset
+	keep if 		round == 1 | round == 3 | round == 4
 
-	loc idhvars 	hhnum   							// store idh vars in local
-
+		* IDH construction for rounds 1-3
+		loc idhvars 	pufhhnum 	// store idh vars in local
 
 	ds `idhvars',  	has(type numeric)					// filter out numeric variables in local
 	loc numlist 	= r(varlist)						// store numeric vars in local
@@ -253,6 +263,20 @@ replace int_month = 10 	if round == 4
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
 	}
+
+		* make each string variable numeric (as it should be), then string again with correct format
+		foreach var of local stringlist {
+			destring `var' /// 								// destring variable, make numeric version
+				, gen(num_`var') ///						//
+				force 										// force obs to num that are non numeric, ie to missing
+
+			tostring num_`var'	///							// make the numeric vars strings
+				, generate(idh_`var') ///					// gen a variable with this prefix
+				force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
+
+			loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+		}
 
 		* add the round variable
 		tostring round	///							// make the numeric vars strings
@@ -277,7 +301,7 @@ replace int_month = 10 	if round == 4
 	* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
 	*	so, not following processing for sorting numeric/non-numeric variables.
 
-	loc idpvars 	c101_lno 							// store relevant idp vars in local
+	loc idpvars 	pufc01_lno 							// store relevant idp vars in local
 	ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
 	loc rlist 		= r(varlist)						// store numeric vars in local
 
@@ -300,8 +324,134 @@ replace int_month = 10 	if round == 4
 	sort idh idp
 	label var idp "Individual id"
 
+	** Manage duplicates
+		/*There are 1 duplicated observations across pufhhnum, round, c101_lno,
+	 	or 2 total pairs of duplicates. These all occur in c101_lno (line number). What appears to be
+		this combination of variables determines households except for these 8 observations, which occur
+		all in the same constructed household id. For now, I will
+		simply drop all observations that pertain to this household id
+		until/if coming up with a more objective way to distinguish between
+		households. */
+
+	duplicates report	idh idp							// for record keeping
+	duplicates tag 		idh idp	 						/// create a 1/0 var that tags the duplicate observations
+	 					, generate(hhid_dup_obs)		// (note this does not tage all obs in the household)
+	sort idh
+	by idh: 	egen 	hhid_dup_hh	= max(hhid_dup_obs)	// this var will tell us if any obs in the hh is duplicated
+
+
+	drop if 			hhid_dup_hh == 1				// drop all obs in household if household has duplicated hhid obs
+	assert 				r(N_drop) 	== 4				// we know that 4 obs should be dropped under these conditions.
+
+
+
+
 ** ID CHECKS
+	duplicates report idh idp
 	isid idh idp 										// household and individual id uniquely identify
+
+
+
+	save 	`partA', 	replace 							// save tempfile for partA
+	restore													// restore to original 4-round dataset
+
+	preserve   												// preserve the original appended dataset
+	keep if 		round == 2 								// keep round 4/october only
+
+
+
+		* IDH construction for round 4
+		loc idhvars 	pufreg l1prrcd l1mun l1ea lhusn l1bgy lhsn pufpsu 	// store idh vars in local
+
+		ds `idhvars',  	has(type numeric)					// filter out numeric variables in local
+		loc numlist 	= r(varlist)						// store numeric vars in local
+		loc stringlist 	: list idhvars - numlist			// non-numeric vars in stringlist
+
+		* starting locals
+		loc len = 4										// declare the length of each element in digits
+		loc idh_els ""										// start with empty local list
+
+		* make each numeric var string, including leading zeros
+		foreach var of local numlist {
+			tostring `var'	///								// make the numeric vars strings
+				, generate(idh_`var') ///					// gen a variable with this prefix
+				force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
+
+			loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+		}
+
+		* make each string variable numeric (as it should be), then string again with correct format
+		foreach var of local stringlist {
+			destring `var' /// 								// destring variable, make numeric version
+				, gen(num_`var') ///						//
+				force 										// force obs to num that are non numeric, ie to missing
+
+			tostring num_`var'	///							// make the numeric vars strings
+				, generate(idh_`var') ///					// gen a variable with this prefix
+				force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
+
+			loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+		}
+
+		* add the round variable
+		tostring round	///							// make the numeric vars strings
+			, generate(idh_round) ///					// gen a variable with this prefix
+			force format(`"%01.0f"')				// ...and the specified number of digits in local
+
+		loc idh_els 	`idh_els' idh_round				// add each variable to the local list
+
+
+
+		* concatenate all elements to form idh: hosehold id
+		egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
+
+		label var idh "Household id"
+
+
+
+
+		** INDIVIDUAL IDENTIFICATION NUMBER
+		bys idh: gen n_fam = _n								// generate family member number
+
+		* repeat same process from above, but only with n_fam.
+		* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
+		*	so, not following processing for sorting numeric/non-numeric variables.
+
+		loc idpvars 	pufc01_lno								// store relevant idp vars in local
+		ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
+		loc rlist 		= r(varlist)						// store numeric vars in local
+
+		* make new values with desired length of each variable
+		loc len = 2											// declare the length of each element in digits
+		loc idp_els ""										// start with empty local list
+
+		foreach var of local idpvars {
+			tostring `var'	///								// make numeric variables strings
+				, generate(idp_`var') ///					// generate a variable with this prefix
+				force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
+
+			loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
+
+		}
+
+		* concatenate to form idp: individual id
+		egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
+
+		sort idh idp
+		label var idp "Individual id"
+
+	** ID CHECKS
+		isid idh idp 										// household and individual id uniquely identify
+
+
+	save 	`partB', 	replace 							// save the final round to a tempfile.
+
+	restore 												// restore to old dataset
+	clear
+
+	append using 		`partA' `partB'
 
 
 	gen  hhid = idh  									// make hhid from idh in module
@@ -320,15 +470,14 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	rename 		`weightvar'	weight_orig
+	gen 		weight = weight_orig / 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
 
 *<_psu_>
-	rename 		psu psu_orig
-	gen 		psu = psu_orig
+	gen 		psu = pufpsu
 	label 		var psu "Primary sampling units"
 *</_psu_>
 
@@ -340,7 +489,8 @@ replace int_month = 10 	if round == 4
 
 
 *<_strata_>
-	gen strata = stratum
+	* no explicit strata variable given in 2017
+	gen strata = .
 	label var strata "Strata"
 *</_strata_>
 
@@ -367,7 +517,7 @@ replace int_month = 10 	if round == 4
 
 *<_urban_>
 	gen byte 		urban = .
-	replace 		urban = urb2k70
+	replace 		urban = pufurb2k10
 	recode 			urban (2 = 0) 		// change rural=2 to rural=0
 	label var 		urban "Location is urban"
 	la de 			lblurban 1 "Urban" 0 "Rural"
@@ -381,7 +531,7 @@ replace int_month = 10 	if round == 4
 	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
 
 </_subnatid1> */
-	gen byte 		subnatid1 = reg
+	gen byte 		subnatid1 = pufreg
 	label de 		lblsubnatid1 	///
 					 1   "1 - Ilocos"			///
 					 2	 "2 - Cagayan Valley"	///
@@ -395,12 +545,12 @@ replace int_month = 10 	if round == 4
 					 10  "10 - Northern Mindanao"	///
 					 11  "11 - Davao"	///
 					 12  "12 - Soccsksargen"		///
-					 13  "13 - National Capital Region"				///
-					 14  "14 - Cordillera Administrative Region"		///
-					 15  "15 - Autonomous Region of Muslim Mindanao"	///
+					 13  "13 - National Capital pufregion"				///
+					 14  "14 - Cordillera Administrative pufregion"		///
+					 15  "15 - Autonomous pufregion of Muslim Mindanao"	///
 					 16  "16 - Caraga" ///
 					 /// value 17 exists only in raw data, not in recoded version
-					 18  "18 - Negros Island Region" /// this region appears occasionally in data
+					 18  "18 - Negros Island pufregion" /// this pufregion appears occasionally in data
 				 	 							///
 				 	 41	 "41 - Calabarzon"	/// formerly part of Southern Tagalog
 				 	 42  "42 - Mimaropa"		// formerly part of Southern Tagalog
@@ -440,7 +590,7 @@ replace int_month = 10 	if round == 4
 	}
 
 	// generate the variable and apply the labels.
-	gen byte 		subnatid2 = prov
+	gen byte 		subnatid2 = pufprv
 	label values 	subnatid2 lblsubnatid2
 	label var 		subnatid2 "Subnational ID at Second Administrative Level"
 
@@ -511,7 +661,7 @@ replace int_month = 10 	if round == 4
 
 *<_hsize_>
 	sort hhid
-	by hhid: egen hsize= count(c05_rel <= 8 | c05_rel == 11) // includes non-family members, not boarders or domestic workers.
+	by hhid: egen hsize= count(pufc03_rel <= 8 | pufc03_rel == 11) // includes non-family members, not boarders or domestic workers.
 	label var 	hsize "Household size"
 
 	* check
@@ -522,14 +672,14 @@ replace int_month = 10 	if round == 4
 
 
 *<_age_>
-	gen 		age = c07_age
+	gen 		age = pufc05_age
 	replace 	age	= 98 	if age>=98 & age!=.
 	label var 	age "Individual age"
 *</_age_>
 
 
 *<_male_>
-	gen 		male = c06_sex
+	gen 		male = pufc04_sex
 	recode 		male (2 = 0)						// female=2 recoded to female=0
 	label var 	male "Sex - Ind is male"
 	la de 		lblmale 	1 "Male" 0 "Female"
@@ -539,7 +689,7 @@ replace int_month = 10 	if round == 4
 
 *<_relationharm_>
 	gen 		relationharm = .
-	replace 	relationharm = c05_rel
+	replace 	relationharm = pufc03_rel
 	recode 		relationharm (4 5 6 8  	= 5) /// siblings, children in law, grandchildren, other rel of hh head="other relatives"
 					(7 			= 4)	/// parents of hh head become "parents"
 					(9 10 11 	= 6) 	// boarders and domestic workers become "other/non-relatives"
@@ -566,13 +716,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_relationcs_>
-	gen relationcs = c05_rel
+	gen relationcs = pufc03_rel
 	label var relationcs "Relationship to the head of household - Country original"
 *</_relationcs_>
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+	gen byte 		marital = pufc06_mstat
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -717,7 +867,7 @@ label var ed_mod_age "Education module application age"
 *</_ed_mod_age_>
 
 *<_school_>
-	gen byte school= a02_csch
+	gen byte school= pufc08_cursch
 	recode school (2 = 0)		// 2 was "no", recode to 0. Keep 1=Yes same.
 	label var school "Attending school"
 	la de lblschool 0 "No" 1 "Yes"
@@ -744,15 +894,26 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte 	educat7=.
+	replace 	educat7=1 if pufc07_grade <= 110 		// less than primary to "no education"
+	replace 	educat7=2 if (pufc07_grade >= 110 & pufc07_grade <= 160) /// Grades 1-6 -> "primary incomplete"
+							| (pufc07_grade >=410 & pufc07_grade <= 450) // grade 1-5 in K-12 program->"Primary incomplete"
+	replace 	educat7=3 if pufc07_grade == 170 		/// grade 6 graduate -> "primary complete"
+							| pufc07_grade == 180 	/// grade 7 graduate -> "primary complete"
+							| pufc07_grade == 460  	// grade 6 in k-12 school to "Primary Complete"
+	replace 	educat7=4 if (pufc07_grade >= 210 & pufc07_grade <= 240) /// 1-4th year in secondary school
+							| (pufc07_grade >=470 & pufc07_grade <= 490) // ...or grade 7-9 in k-12 program -> "secondary incomplete"
+	replace 	educat7=5 if pufc07_grade == 250		/// high school complete
+							| pufc07_grade == 500 	// ... or "grade 10" in K-12 to to "Secondary Complete"
+	replace 	educat7=6 if (pufc07_grade >= 601 & pufc07_grade <= 699) 	/// the 600s are for post-secondary/non-uni track courses
+							| (pufc07_grade >= 510 & pufc07_grade <= 520) // and grade 11 and 12 in K-12 -> "post second./non uni"
 
+	replace 	educat7=7 if ( pufc07_grade>=701 & pufc07_grade<=950) 	// 1st-6th yr college, Tertiary degrees and above to "Uni"
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
+/*There's no documentation on where to classify SPED, but for now I will include
+undergraduates in "primary" and "graduates" in "secondary" */
+	replace 	educat7=3 if  pufc07_grade == 191
+	replace 	educat7=5 if 	pufc07_grade == 192
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +954,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = pufc07_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -881,7 +1042,7 @@ foreach v of local ed_var {
 
 {
 *<_lstatus_>
-	gen byte 		lstatus = newempst
+	gen byte 		lstatus = pufnewempstat
 	replace 		lstatus = . if age < minlaborage
 	label var 		lstatus "Labor status"
 	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF" // raw values always same as new
@@ -892,8 +1053,8 @@ foreach v of local ed_var {
 *<_potential_lf_>
 	gen byte 		potential_lf = 0
 
-	replace 		potential_lf = 1 if (c37_avil == 1 & c38_lokw == 2) ///
-										| (c37_avil == 2 & c38_lokw == 1)
+	replace 		potential_lf = 1 if (pufc36_avail == 1 & pufc30_lookw == 2) ///
+										| (pufc36_avail == 2 & pufc30_lookw == 1)
 	replace 		potential_lf = . if age < minlaborage & age != .
 	replace 		potential_lf = . if lstatus != 3
 	label var 		potential_lf "Potential labour force status"
@@ -905,7 +1066,7 @@ foreach v of local ed_var {
 *<_underemployment_>
 	gen byte 		underemployment = 0
 
-	replace 		underemployment = 1 if c23_pwmr == 1
+	replace 		underemployment = 1 if pufc20_pwmore == 1
 	replace 		underemployment = . if age < minlaborage & age != .
 	replace 		underemployment = . if lstatus != 1
 	label var 		underemployment "Underemployment status"
@@ -916,11 +1077,11 @@ foreach v of local ed_var {
 
 *<_nlfreason_>
 	gen byte 		nlfreason= .
-	replace 		nlfreason=1 	if c42_wynt==8
-	replace 		nlfreason=2 	if c42_wynt==7
-	replace 		nlfreason=3 	if c42_wynt==6
-	replace 		nlfreason=4 	if c42_wynt==3
-	replace 		nlfreason=5 	if c42_wynt==1 | c42_wynt==2 | c42_wynt==4 | c42_wynt==5 | c42_wynt==9
+	replace 		nlfreason=1 	if pufc34_wynot==8
+	replace 		nlfreason=2 	if pufc34_wynot==7
+	replace 		nlfreason=3 	if pufc34_wynot==6
+	replace 		nlfreason=4 	if pufc34_wynot==3
+	replace 		nlfreason=5 	if pufc34_wynot==1 | pufc34_wynot==2 | pufc34_wynot==4 | pufc34_wynot==5 | pufc34_wynot==9
 	replace 		nlfreason=. 	if lstatus!=3 		// restricts universe to non-labor force
 	label var 		nlfreason "Reason not in the labor force"
 	la de 			lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
@@ -929,7 +1090,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_l_>
-	gen byte 		unempldur_l=c40_wks/4.2
+	gen byte 		unempldur_l=pufc33_weeks/4.2
 	label var 		unempldur_l "Unemployment duration (months) lower bracket"
 	replace 		unempldur_l=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -937,7 +1098,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_u_>
-	gen byte 		unempldur_u=c40_wks/4.2
+	gen byte 		unempldur_u=pufc33_weeks/4.2
 	label var 		unempldur_u "Unemployment duration (months) upper bracket"
 	replace 		unempldur_u=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -951,10 +1112,10 @@ foreach v of local ed_var {
 {
 *<_empstat_>
 	gen byte 		empstat=.
-	replace 		empstat=1 	if c19pclas==0 | c19pclas==1 | c19pclas==2 | c19pclas==5
-	replace 		empstat=2 	if c19pclas==6
-	replace 		empstat=3	if c19pclas==4
-	replace 		empstat=4 	if c19pclas==3
+	replace 		empstat=1 	if pufc23_pclass==0 | pufc23_pclass==1 | pufc23_pclass==2 | pufc23_pclass==5
+	replace 		empstat=2 	if pufc23_pclass==6
+	replace 		empstat=3	if pufc23_pclass==4
+	replace 		empstat=4 	if pufc23_pclass==3
 	replace 		empstat=. 	if lstatus!=1 	// includes universe restriction
 	label var 		empstat 	"Employment status during past week primary job 7 day recall"
 	la de 			lblempstat 	1 "Paid employee" ///
@@ -968,8 +1129,8 @@ foreach v of local ed_var {
 
 *<_ocusec_>
 	gen byte 		ocusec = .
-	replace 		ocusec = 1 	if c19pclas == 2
-	replace 		ocusec = 2 	if inlist(c19pclas, 0, 1, 3, 4, 5, 6)
+	replace 		ocusec = 1 	if pufc23_pclass == 2
+	replace 		ocusec = 2 	if inlist(pufc23_pclass, 0, 1, 3, 4, 5, 6)
 
 	label var 		ocusec 		"Sector of activity primary job 7 day recall"
 	la de 			lblocusec 	1 "Public Sector, Central Government, Army" ///
@@ -981,13 +1142,18 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_>
-	gen 			industry_orig = c18_pkb
+	gen 			industry_orig = pufc16_pkb
 	label var 		industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 
 
 *<_industrycat_isic_>
-	loc matchvar   	c18_pkb
+	/* The key that matches industry codes is in string format to maintain leading/trailing
+		zeros, so we will change the format here to string if necessary.
+
+		Note that the isic match will only be valid for wave 2 or April round */
+
+	loc matchvar   	pufc16_pkb
 	loc n 			1
 
 	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -999,44 +1165,109 @@ foreach v of local ed_var {
 			tostring industry_orig	///						// make the numeric vars strings
 				, generate(industry_orig_str) ///			// gen a variable with this prefix
 				force //
+
+
 		}
 
 
-	// merge sub-module with isic key
+	// merge sub-module with isic 4 dig key (for waves 2)
 
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
+	gen class = `matchvar'
+	tostring 	class ///
+				, format(`"%04.0f"') replace
 
+	replace 	class = "" if class == "." // fix missing
+	replace 	class = "" if wave != "Q2" // only match second wave
+
+	// merge with isic
 	merge 		m:1 ///
-				psic_2dig ///
+				class ///
 				using `isic_key' ///
 				, generate(isic_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4	isic4_`n'
+	replace 	isic4_`n' = "6810" 	if `matchvar' == 6819
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	* now the missing obs in class are those in waves 2 that didn't match isco12 and
+	* all obs in wave1, 3,4
 
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+
+	// merge with 2 digit key (for waves 1, 3,4)
+	gen 		psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	replace 	psic_2dig = "" if psic_2dig == "." // fix missing
+	replace 	psic_2dig = "" if wave == "Q2" // merge only for q2
+
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isic_key2dig' ///
+				, generate(isic_mergeb_`n') ///
+				keep(master match) /// "left join"; remove obs that don't match from using
+				keepusing(psic_2dig isic4_2dig_pad)
+
+	rename 		isic4_2dig_pad isic4_2dig_`n'
+
+	// coalesce 2 variables
+	egen str4 	industrycat_isic = rowfirst(isic4_`n' isic4_2dig_`n')
+
+	drop 		psic_2dig class 				// no longer needed, maintained in matchvar
+
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
-	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	gen byte industrycat10=.
+
+	* for months January, July, October
+		replace industrycat10=1 	if (pufc16_pkb>=1 	& pufc16_pkb<=4) ///
+								& (round == 1 | round == 3 | round == 4)	// to Agriculture
+		replace industrycat10=2 	if (pufc16_pkb>=5 	& pufc16_pkb<=9) ///
+								& (round == 1 | round == 3 | round == 4)	// to Mining
+		replace industrycat10=3 	if (pufc16_pkb>=10 & pufc16_pkb<=33)	///
+								& (round == 1 | round == 3 | round == 4) // to Manufacturing
+		replace industrycat10=4 	if (pufc16_pkb>=35 & pufc16_pkb<=39)  ///
+								& (round == 1 | round == 3 | round == 4)	// to Public utility
+		replace industrycat10=5 	if (pufc16_pkb>=41 & pufc16_pkb<=43)  ///
+								& (round == 1 | round == 3 | round == 4)	// to Construction
+		replace industrycat10=6 	if (pufc16_pkb>=45 & pufc16_pkb<=47) | (pufc16_pkb >= 55 & pufc16_pkb <= 56)  ///
+								& (round == 1 | round == 3 | round == 4)	// to Commerce
+		replace industrycat10=7 	if (pufc16_pkb>=49 & pufc16_pkb<=53) | (pufc16_pkb >= 58 & pufc16_pkb <= 63)  ///
+								& (round == 1 | round == 3 | round == 4) // to Transport/coms
+		replace industrycat10=8 	if (pufc16_pkb>=64 & pufc16_pkb<=82)   ///
+								& (round == 1 | round == 3 | round == 4)	// to financial/business services
+		replace industrycat10=9 	if (pufc16_pkb==84) 		  ///
+								& (round == 1 | round == 3 | round == 4)		// to public administration
+		replace industrycat10=10 if (pufc16_pkb>=91 & pufc16_pkb<=99)   ///
+								& (round == 1 | round == 3 | round == 4) // to other
+		replace industrycat10=10 if industrycat10==. & pufc16_pkb!=.  ///
+								& (round == 1 | round == 3 | round == 4)
+
+
+
+	if (round == 2) {
+		* For April, code according to the april Schema
+
+		replace industrycat10=1 	if pufc16_pkb >= 100 	& pufc16_pkb <= 399	 	// "Agriculture, Forestry, Fishing" coded to "Agriculture"
+		replace industrycat10=2 	if pufc16_pkb >= 500 	& pufc16_pkb <= 999		// "Mining and Quarrying" coded to "Mining"
+		replace industrycat10=3 	if pufc16_pkb >= 1000 	& pufc16_pkb <= 3399 	// "Manufacturing" coded to "Manufacturing"
+		replace industrycat10=4 	if pufc16_pkb >= 3500 	& pufc16_pkb <= 3900	// "Water supply, sewerage, etc" coded to "Public Utiltiy"
+		replace industrycat10=5 	if pufc16_pkb >= 4100 	& pufc16_pkb <= 4399	// "Construction" coded to "Construction"
+		replace industrycat10=6 	if pufc16_pkb >= 4500 	& pufc16_pkb <= 4799	// "Wholesale/retail, repair of vehicles" to "Commerce"
+		replace industrycat10=7 	if pufc16_pkb >= 4900 	& pufc16_pkb <= 5399	// "Transport+storage" to "Transport". UN codes include storage
+		replace industrycat10=6 	if pufc16_pkb >= 5500 	& pufc16_pkb <= 5699	// "Accommodation+Food" to "Commerce"
+		replace industrycat10=7 	if pufc16_pkb >= 5800 	& pufc16_pkb <= 6399	// "Information+communication" to "Transport/Communication"
+		replace industrycat10=8 	if pufc16_pkb >= 6400 	& pufc16_pkb <= 8299	// "Misc Business Services" to "Business Services"
+		replace industrycat10=9 	if pufc16_pkb >= 8400 	& pufc16_pkb <= 8499	// "public administration/defense" to "public administration"
+		replace industrycat10=10	if pufc16_pkb >= 8500 	& pufc16_pkb <= 9950	// "Other services" including direct education to "other"
+
+	}
+
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1061,7 +1292,7 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_>
-	gen 			occup_orig = c16_proc
+	gen 			occup_orig = pufc14_procc
 	label var 		occup_orig "Original occupation record primary job 7 day recall"
 	replace 		occup_orig=. if lstatus!=1 			// restrict universe to employed only
 	replace 		occup_orig=. if age < minlaborage	// restrict universe to working age
@@ -1069,7 +1300,9 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-	loc matchvar   	c16_proc
+* in 2017, raw variable is numeric, 2-digits, so isco conversion not possible
+	 **Working on isco key, leaving as misisng for now
+	loc matchvar   	pufc14_procc
 	loc n 			1
 
 	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1080,38 +1313,79 @@ foreach v of local ed_var {
 															// run this if == 1 (ie, if occup_orig is numeric)
 			tostring occup_orig	///						// make the numeric vars strings
 				, generate(occup_orig_str) ///			// gen a variable with this prefix
-				force
+				force //
+
+
 		}
 
 
-	// merge sub-module with isco key
+	// merge sub-module with isco key (wave 2 only)
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
+	gen unit = `matchvar'
+	tostring 	unit ///
+				, format(`"%04.0f"') replace
+
+	replace 	unit = "" if unit == "." // fix missing
+	replace 	unit = "" if wave != "Q2" // merge only for q2
 
 	merge 		m:1 ///
-				psoc92 ///
+				unit ///
 				using `isco_key' ///
 				, generate(isco_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
+				keep(master match) /// "left join"; remove obs that don't match from using
+				keepusing(unit isco08)
+
+	// replace one code that I know doesn't match
+	rename 		isco08	isco08_`n'
+	replace 	isco08_`n' = "6810" 	if `matchvar' == 6819
+
+	// merge with 2 digit key (waves 1, 3,4)
+	drop 		unit
+
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
+				, format(`"%02.0f"') replace
+
+	replace 	psic_2dig = "" if psic_2dig == "." // fix missing
+	replace 	psic_2dig = "" if wave == "Q2" // don't merge q2
 
 
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
+	merge 		m:1 ///
+				psic_2dig ///
+				using `isco_key2dig' ///
+				, generate(isco_mergeb_`n') ///
+				keep(master match) /// "left join"; remove obs that don't match from using
+				keepusing(psic_2dig isco08_2dig_pad)
 
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco = isco88_sub_major_`n'
+	rename 		isco08_2dig_pad isco08_2dig_`n'
+
+	// coalesce 2 variables
+	egen str4	occup_isco = rowfirst(isco08_`n' isco08_2dig_`n')
+
+	drop 		psic_2dig				// no longer needed, maintained in matchvar
+
 	label var 	occup_isco "ISCO code of primary job 7 day recall"
 
 *</_occup_isco_>
 
 
 *<_occup_>
-	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	* in 2017, raw variable is numeric 2 digits only
+	* generate empty variable
+	gen byte occup = .
+
+	* replace conditionally based on January, July, October (2-digit rounds)
+	replace 	occup	=floor(pufc14_procc/10)		if  (round == 1 | round == 3 | round == 4)
+	recode 		occup 	0 = 10	if 	(pufc14_procc >=1 & pufc14_procc <=3)	/// recode "armed forces" to appropriate label
+						& (round == 1 | round == 3 | round == 4)
+
+
+	* replace conditionally based on April (4-digit round)
+	replace 	occup	=floor(pufc14_procc/1000)	if 	round == 2	// this handles most of recoding automatically.
+	recode 		occup 	0 = 10	///
+						if 	(pufc14_procc == 110 | pufc14_procc == 210 | pufc14_procc == 310) /// recode "armed forces" to appropriate label
+						& 	(round == 2)
+
 
 	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
 	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
@@ -1146,7 +1420,7 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_>
-	gen 			double wage_no_compen = c27_pbsc
+	gen 			double wage_no_compen = pufc25_pbasic
 	replace 		wage_no_compen = . if 	wage_no_compen == 99999
 	label var 		wage_no_compen "Last wage payment primary job 7 day recall"
 *</_wage_no_compen_>
@@ -1173,7 +1447,7 @@ foreach v of local ed_var {
 
 
 *<_whours_>
-	gen whours 		= c22_phrs
+	gen whours 		= pufc28_thours
 	label var whours "Hours of work in last week primary job 7 day recall"
     replace 		whours = 84 	if whours > 84 & whours != . 	// replace unrealistic work weeks
 *</_whours_>
@@ -1248,7 +1522,7 @@ foreach v of local ed_var {
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
 /*
-2010 has no secondary job information.
+2017 has no secondary job information.
 */
 
 {
@@ -1267,64 +1541,23 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_2_>
-	gen 			industry_orig_2 = j03_okb
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			industry_orig_2 = .
 	label var 		industry_orig_2 "Original survey industry code, secondary job 7 day recall"
 *</_industry_orig_2_>
 
 
 *<_industrycat_isic_2_>
-	loc matchvar   	j03_okb
-	loc n 			2
+	gen 			industrycat_isic_2 = .
+	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 
-	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc isicvar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if industry_orig is numeric)
-			tostring industry_orig_2	///						// make the numeric vars strings
-				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
-				force //
-		}
-
-
-	// merge sub-module with isic key
-
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psic_2dig ///
-				using `isic_key' ///
-				, generate(isic_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-				* the string variable in isic4 will is industrycat_isic
-
-	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
-
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
-
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
-	gen byte 		industrycat10_2 = .
-
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
-
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+	gen byte 			industrycat10_2 = .
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
 *</_industrycat10_2_>
@@ -1339,45 +1572,18 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_2_>
-	gen 			occup_orig_2 = j02_otoc
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			occup_orig_2 = .
 	label var 		occup_orig_2 "Original occupation record secondary job 7 day recall"
 *</_occup_orig_2_>
 
 
 *<_occup_isco_2_>
-	loc matchvar   	j02_otoc
-	loc n 			2
-
-	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc iscovar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if occup_orig is numeric)
-			tostring occup_orig_2	///						// make the numeric vars strings
-				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
-				force
-		}
-
-
-	// merge sub-module with isco key
-
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psoc92 ///
-				using `isco_key' ///
-				, generate(isco_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-
-
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
-
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco_2 = isco88_sub_major_`n'
+	gen occup_isco_2 = ""
 	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
+
+
 *</_occup_isco_2_>
 
 
@@ -1390,10 +1596,9 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
-							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen byte occup_2 = .
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup
@@ -1401,14 +1606,14 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen 			double wage_no_compen_2 = c36_obic
+	gen 			double wage_no_compen_2 = .
 	replace 		wage_no_compen_2 = . if wage_no_compen_2 == 99999
 	label var 		wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obis
+	gen byte 		unitwage_2 = .
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly
@@ -1421,7 +1626,7 @@ foreach v of local ed_var {
 
 
 *<_whours_2_>
-	gen 			whours_2 = j05_ohrs
+	gen 			whours_2 = .
 	label var 		whours_2 "Hours of work in last week secondary job 7 day recall"
 *</_whours_2_>
 
@@ -1938,7 +2143,7 @@ foreach v of local ed_var {
 
 *<_njobs_>
 	*<_njobs_note>
-	* The provided njobs data appears to be inconsistent with data, so I dedicded not to include.
+	* The pufprvided njobs data appears to be inconsistent with data, so I dedicded not to include.
 	*</_njobs_note>
 
 	gen 			njobs = .

--- a/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v03_A_GLD/Programs/PHL_2018_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2018_LFS/PHL_2018_LFS_v01_M_v03_A_GLD/Programs/PHL_2018_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2018_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,30 +13,31 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2018 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2018] </_Data collection from_>
+<_Data collection to_>			[10/2018] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
-<_Sampling method_> 			Geographic regions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
-<_Geographic coverage_> 		1st-level Subdivision (Region) </_Geographic coverage_>
+<_Sampling method_> 			Geographic pufregions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
+<_Geographic coverage_> 		1st-level Subdivision (pufregion) </_Geographic coverage_>
 <_Currency_> 					[Currency used for wages] </_Currency_>
 
 -----------------------------------------------------------------------
 
 <_ICLS Version_>				ICLS-13 </_ICLS Version_>
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
-<_ISCO Version_>				ISCO 88 </_ISCO Version_>
-<_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISCO Version_>				ISCO 08 </_ISCO Version_>
+<_OCCUP National_>				PSOC 12 </_OCCUP National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-30] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2018			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,33 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	pufpwgtprv // final weightvar
+
+** LOG FILE
+	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFS JAN2018.dta"'
+	local round2 `"`stata'\LFS APR2018.dta"'
+	local round3 `"`stata'\LFS JUL2018.dta"'
+	local round4 `"`stata'\LFS OCT2018.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig_updated.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key_2dig.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -118,7 +122,34 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
 		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		, clear surveys(JAN2018 APR2018 JUL2018 OCT2018) generate(round) // survey names
+
+
+
+** Align HHID variables
+	** align hhnum
+	/*rounds 1,3,4 (january,, july, october) have a numeric household id called hhnum whereas round 2 (april)
+	  has a string numeric variable encoded as str23. Since the ids will all be the same legth anyway, I will
+	  change rounds 1-3 to be a str23 to match round 4 so I can replace and "align" the hhnum as a string
+	  variable for all 4 rounds*/
+
+	*** encode hhnum as string
+	rename 		pufhhnum 	hhnum_num					// rename to numeric indicator name
+
+	tostring 	hhnum_num	///						// make the numeric vars strings
+				, generate(hhnum_str11) ///			// generate new variable as a string
+				force format(`"%011.0f"')				// ...and the specified number of digits in local
+
+	gen 		hhnum = ""								// generate household ID variable
+	replace 	hhnum = hhnum_str11 	if round == 1 /// replace conditionally on round,
+										| round == 3  ///
+										| round == 4
+	replace 	hhnum = pufhhnum_2			if round == 2
+
+	mdesc 		hhnum 								// ensure that hhid has no missings
+	assert	 	r(miss) == 0
+
+
 
 
 /*%%=============================================================================================
@@ -157,13 +188,13 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isco_version_>
-	gen isco_version = "isco_1988"
+	gen isco_version = "isco_2008"
 	label var isco_version "Version of ISCO used"
 *</_isco_version_>
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +212,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -199,7 +230,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_int_month_>
-	gen  int_month = svymo
+	gen  int_month = pufsvymo
 	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
 	label value int_month lblint_month
 	label var int_month "Month of the interview"
@@ -221,8 +252,8 @@ replace int_month = 10 	if round == 4
 	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
 	002, ..., 160.
 
-	Since individual Household ID variables were not always provided for the Philippines, yet the household
-	line number variables were provided, it was possible to approximate the household groupings by other variables.
+	Since individual Household ID variables were not always pufprvided for the Philippines, yet the household
+	line number variables were pufprvided, it was possible to approximate the household groupings by other variables.
 	However, this process was not perfectly clean, so checks for duplicates were needed. Please refer to the
 	"Household_IDs.md" in Guides and Documentation for additional explanation. The two variables, hhid and pid
 	will be produced in conjunction, the labelled in the html brackets.
@@ -230,36 +261,17 @@ replace int_month = 10 	if round == 4
 </_hhid_note> */
 ** HOUSEHOLD IDENTIFICATION NUMBER
 
-** HOUSEHOLD IDENTIFICATION NUMBER
-
 
 	loc idhvars 	hhnum   							// store idh vars in local
 
 
-	ds `idhvars',  	has(type numeric)					// filter out numeric variables in local
-	loc numlist 	= r(varlist)						// store numeric vars in local
-	loc stringlist 	: list idhvars - numlist			// non-numeric vars in stringlist
-
-	* starting locals
-	loc len = 14											// declare the length of each element in digits
-	loc idh_els ""										// start with empty local list
-
-	* make each numeric var string, including leading zeros
-	foreach var of local numlist {
-		tostring `var'	///								// make the numeric vars strings
-			, generate(idh_`var') ///					// gen a variable with this prefix
-			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
-
-		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
-
-	}
 
 		* add the round variable
 		tostring round	///							// make the numeric vars strings
 			, generate(idh_round) ///					// gen a variable with this prefix
 			force format(`"%01.0f"')				// ...and the specified number of digits in local
 
-		loc idh_els 	`idh_els' idh_round				// add each variable to the local list
+		loc idh_els 	hhnum idh_round				// add each variable to the local list
 
 
 	* concatenate all elements to form idh: hosehold id
@@ -277,7 +289,7 @@ replace int_month = 10 	if round == 4
 	* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
 	*	so, not following processing for sorting numeric/non-numeric variables.
 
-	loc idpvars 	c101_lno 							// store relevant idp vars in local
+	loc idpvars 	pufc01_lno 							// store relevant idp vars in local
 	ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
 	loc rlist 		= r(varlist)						// store numeric vars in local
 
@@ -320,15 +332,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	gen 		weight = pufpwgtprv / 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
 
 *<_psu_>
-	rename 		psu psu_orig
-	gen 		psu = psu_orig
+	gen 		psu = pufpsu
 	label 		var psu "Primary sampling units"
 *</_psu_>
 
@@ -340,7 +350,8 @@ replace int_month = 10 	if round == 4
 
 
 *<_strata_>
-	gen strata = stratum
+	* no explicit strata variable given in 2018
+	gen strata = .
 	label var strata "Strata"
 *</_strata_>
 
@@ -367,7 +378,7 @@ replace int_month = 10 	if round == 4
 
 *<_urban_>
 	gen byte 		urban = .
-	replace 		urban = urb2k70
+	replace 		urban = pufurb2k10
 	recode 			urban (2 = 0) 		// change rural=2 to rural=0
 	label var 		urban "Location is urban"
 	la de 			lblurban 1 "Urban" 0 "Rural"
@@ -381,7 +392,7 @@ replace int_month = 10 	if round == 4
 	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
 
 </_subnatid1> */
-	gen byte 		subnatid1 = reg
+	gen byte 		subnatid1 = pufreg
 	label de 		lblsubnatid1 	///
 					 1   "1 - Ilocos"			///
 					 2	 "2 - Cagayan Valley"	///
@@ -395,12 +406,12 @@ replace int_month = 10 	if round == 4
 					 10  "10 - Northern Mindanao"	///
 					 11  "11 - Davao"	///
 					 12  "12 - Soccsksargen"		///
-					 13  "13 - National Capital Region"				///
-					 14  "14 - Cordillera Administrative Region"		///
-					 15  "15 - Autonomous Region of Muslim Mindanao"	///
+					 13  "13 - National Capital pufregion"				///
+					 14  "14 - Cordillera Administrative pufregion"		///
+					 15  "15 - Autonomous pufregion of Muslim Mindanao"	///
 					 16  "16 - Caraga" ///
 					 /// value 17 exists only in raw data, not in recoded version
-					 18  "18 - Negros Island Region" /// this region appears occasionally in data
+					 18  "18 - Negros Island pufregion" /// this pufregion appears occasionally in data
 				 	 							///
 				 	 41	 "41 - Calabarzon"	/// formerly part of Southern Tagalog
 				 	 42  "42 - Mimaropa"		// formerly part of Southern Tagalog
@@ -440,7 +451,7 @@ replace int_month = 10 	if round == 4
 	}
 
 	// generate the variable and apply the labels.
-	gen byte 		subnatid2 = prov
+	gen byte 		subnatid2 = pufprv
 	label values 	subnatid2 lblsubnatid2
 	label var 		subnatid2 "Subnational ID at Second Administrative Level"
 
@@ -511,7 +522,7 @@ replace int_month = 10 	if round == 4
 
 *<_hsize_>
 	sort hhid
-	by hhid: egen hsize= count(c05_rel <= 8 | c05_rel == 11) // includes non-family members, not boarders or domestic workers.
+	by hhid: egen hsize= count(pufc03_rel <= 8 | pufc03_rel == 11) // includes non-family members, not boarders or domestic workers.
 	label var 	hsize "Household size"
 
 	* check
@@ -522,14 +533,14 @@ replace int_month = 10 	if round == 4
 
 
 *<_age_>
-	gen 		age = c07_age
+	gen 		age = pufc05_age
 	replace 	age	= 98 	if age>=98 & age!=.
 	label var 	age "Individual age"
 *</_age_>
 
 
 *<_male_>
-	gen 		male = c06_sex
+	gen 		male = pufc04_sex
 	recode 		male (2 = 0)						// female=2 recoded to female=0
 	label var 	male "Sex - Ind is male"
 	la de 		lblmale 	1 "Male" 0 "Female"
@@ -539,7 +550,7 @@ replace int_month = 10 	if round == 4
 
 *<_relationharm_>
 	gen 		relationharm = .
-	replace 	relationharm = c05_rel
+	replace 	relationharm = pufc03_rel
 	recode 		relationharm (4 5 6 8  	= 5) /// siblings, children in law, grandchildren, other rel of hh head="other relatives"
 					(7 			= 4)	/// parents of hh head become "parents"
 					(9 10 11 	= 6) 	// boarders and domestic workers become "other/non-relatives"
@@ -566,13 +577,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_relationcs_>
-	gen relationcs = c05_rel
+	gen relationcs = pufc03_rel
 	label var relationcs "Relationship to the head of household - Country original"
 *</_relationcs_>
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+	gen byte 		marital = pufc06_mstat
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -717,7 +728,7 @@ label var ed_mod_age "Education module application age"
 *</_ed_mod_age_>
 
 *<_school_>
-	gen byte school= a02_csch
+	gen byte school= pufc08_cursch
 	recode school (2 = 0)		// 2 was "no", recode to 0. Keep 1=Yes same.
 	label var school "Attending school"
 	la de lblschool 0 "No" 1 "Yes"
@@ -744,15 +755,26 @@ label var ed_mod_age "Education module application age"
 	classificition of how each level is classified and why,
 	available in github repository. */
 
-	gen byte educat7 =.
+	gen byte 	educat7=.
+	replace 	educat7=1 if pufc07_grade <= 110 		// less than primary to "no education"
+	replace 	educat7=2 if (pufc07_grade >= 110 & pufc07_grade <= 160) /// Grades 1-6 -> "primary incomplete"
+							| (pufc07_grade >=410 & pufc07_grade <= 450) // grade 1-5 in K-12 program->"Primary incomplete"
+	replace 	educat7=3 if pufc07_grade == 170 		/// grade 6 graduate -> "primary complete"
+							| pufc07_grade == 180 	/// grade 7 graduate -> "primary complete"
+							| pufc07_grade == 460  	// grade 6 in k-12 school to "Primary Complete"
+	replace 	educat7=4 if (pufc07_grade >= 210 & pufc07_grade <= 240) /// 1-4th year in secondary school
+							| (pufc07_grade >=470 & pufc07_grade <= 490) // ...or grade 7-9 in k-12 program -> "secondary incomplete"
+	replace 	educat7=5 if pufc07_grade == 250		/// high school complete
+							| pufc07_grade == 500 	// ... or "grade 10" in K-12 to to "Secondary Complete"
+	replace 	educat7=6 if (pufc07_grade >= 601 & pufc07_grade <= 699) 	/// the 600s are for post-secondary/non-uni track courses
+							| (pufc07_grade >= 510 & pufc07_grade <= 520) // and grade 11 and 12 in K-12 -> "post second./non uni"
 
+	replace 	educat7=7 if ( pufc07_grade>=701 & pufc07_grade<=950) 	// 1st-6th yr college, Tertiary degrees and above to "Uni"
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
+/*There's no documentation on where to classify SPED, but for now I will include
+undergraduates in "primary" and "graduates" in "secondary" */
+	replace 	educat7=3 if  pufc07_grade == 191
+	replace 	educat7=5 if 	pufc07_grade == 192
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +815,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = pufc07_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -881,7 +903,7 @@ foreach v of local ed_var {
 
 {
 *<_lstatus_>
-	gen byte 		lstatus = newempst
+	gen byte 		lstatus = pufnewempstat
 	replace 		lstatus = . if age < minlaborage
 	label var 		lstatus "Labor status"
 	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF" // raw values always same as new
@@ -892,8 +914,8 @@ foreach v of local ed_var {
 *<_potential_lf_>
 	gen byte 		potential_lf = 0
 
-	replace 		potential_lf = 1 if (c37_avil == 1 & c38_lokw == 2) ///
-										| (c37_avil == 2 & c38_lokw == 1)
+	replace 		potential_lf = 1 if (pufc36_avail == 1 & pufc30_lookw == 2) ///
+										| (pufc36_avail == 2 & pufc30_lookw == 1)
 	replace 		potential_lf = . if age < minlaborage & age != .
 	replace 		potential_lf = . if lstatus != 3
 	label var 		potential_lf "Potential labour force status"
@@ -905,7 +927,7 @@ foreach v of local ed_var {
 *<_underemployment_>
 	gen byte 		underemployment = 0
 
-	replace 		underemployment = 1 if c23_pwmr == 1
+	replace 		underemployment = 1 if pufc20_pwmore == 1
 	replace 		underemployment = . if age < minlaborage & age != .
 	replace 		underemployment = . if lstatus != 1
 	label var 		underemployment "Underemployment status"
@@ -916,11 +938,11 @@ foreach v of local ed_var {
 
 *<_nlfreason_>
 	gen byte 		nlfreason= .
-	replace 		nlfreason=1 	if c42_wynt==8
-	replace 		nlfreason=2 	if c42_wynt==7
-	replace 		nlfreason=3 	if c42_wynt==6
-	replace 		nlfreason=4 	if c42_wynt==3
-	replace 		nlfreason=5 	if c42_wynt==1 | c42_wynt==2 | c42_wynt==4 | c42_wynt==5 | c42_wynt==9
+	replace 		nlfreason=1 	if pufc34_wynot==8
+	replace 		nlfreason=2 	if pufc34_wynot==7
+	replace 		nlfreason=3 	if pufc34_wynot==6
+	replace 		nlfreason=4 	if pufc34_wynot==3
+	replace 		nlfreason=5 	if pufc34_wynot==1 | pufc34_wynot==2 | pufc34_wynot==4 | pufc34_wynot==5 | pufc34_wynot==9
 	replace 		nlfreason=. 	if lstatus!=3 		// restricts universe to non-labor force
 	label var 		nlfreason "Reason not in the labor force"
 	la de 			lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
@@ -929,7 +951,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_l_>
-	gen byte 		unempldur_l=c40_wks/4.2
+	gen byte 		unempldur_l=pufc33_weeks/4.2
 	label var 		unempldur_l "Unemployment duration (months) lower bracket"
 	replace 		unempldur_l=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -937,7 +959,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_u_>
-	gen byte 		unempldur_u=c40_wks/4.2
+	gen byte 		unempldur_u=pufc33_weeks/4.2
 	label var 		unempldur_u "Unemployment duration (months) upper bracket"
 	replace 		unempldur_u=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -951,10 +973,10 @@ foreach v of local ed_var {
 {
 *<_empstat_>
 	gen byte 		empstat=.
-	replace 		empstat=1 	if c19pclas==0 | c19pclas==1 | c19pclas==2 | c19pclas==5
-	replace 		empstat=2 	if c19pclas==6
-	replace 		empstat=3	if c19pclas==4
-	replace 		empstat=4 	if c19pclas==3
+	replace 		empstat=1 	if pufc23_pclass==0 | pufc23_pclass==1 | pufc23_pclass==2 | pufc23_pclass==5
+	replace 		empstat=2 	if pufc23_pclass==6
+	replace 		empstat=3	if pufc23_pclass==4
+	replace 		empstat=4 	if pufc23_pclass==3
 	replace 		empstat=. 	if lstatus!=1 	// includes universe restriction
 	label var 		empstat 	"Employment status during past week primary job 7 day recall"
 	la de 			lblempstat 	1 "Paid employee" ///
@@ -968,8 +990,8 @@ foreach v of local ed_var {
 
 *<_ocusec_>
 	gen byte 		ocusec = .
-	replace 		ocusec = 1 	if c19pclas == 2
-	replace 		ocusec = 2 	if inlist(c19pclas, 0, 1, 3, 4, 5, 6)
+	replace 		ocusec = 1 	if pufc23_pclass == 2
+	replace 		ocusec = 2 	if inlist(pufc23_pclass, 0, 1, 3, 4, 5, 6)
 
 	label var 		ocusec 		"Sector of activity primary job 7 day recall"
 	la de 			lblocusec 	1 "Public Sector, Central Government, Army" ///
@@ -981,18 +1003,15 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_>
-	gen 			industry_orig = c18_pkb
+	gen 			industry_orig = pufc16_pkb
 	label var 		industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 
 
 *<_industrycat_isic_>
-	loc matchvar   	c18_pkb
+	loc matchvar   	pufc16_pkb
 	loc n 			1
 
-	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
-	loc isicvar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
 
 		if (`len' == 1) {
 															// run this if == 1 (ie, if industry_orig is numeric)
@@ -1016,27 +1035,30 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
-	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	gen byte industrycat10=.
+
+	replace 	industrycat10=1 if (pufc16_pkb>=1 & pufc16_pkb<=4)		// to Agriculture
+	replace 	industrycat10=2 if (pufc16_pkb>=5 & pufc16_pkb<=9)		// to Mining
+	replace 	industrycat10=3 if (pufc16_pkb>=10 & pufc16_pkb<=33)	// to Manufacturing
+	replace 	industrycat10=4 if (pufc16_pkb>=35 & pufc16_pkb<=39)	// to Public utility
+	replace 	industrycat10=5 if (pufc16_pkb>=41 &  pufc16_pkb<=43)	// to Construction
+	replace 	industrycat10=6 if (pufc16_pkb>=45 & pufc16_pkb<=47) | (pufc16_pkb>=55 & pufc16_pkb<=56)	// to Commerce
+	replace 	industrycat10=7 if (pufc16_pkb>=49 & pufc16_pkb<=53)| (pufc16_pkb>=58 & pufc16_pkb<=63) // to Transport/coms
+	replace 	industrycat10=8 if (pufc16_pkb>=64 & pufc16_pkb<=82) 	// to financial/business services
+	replace 	industrycat10=9 if (pufc16_pkb==84) 				// to public administration
+	replace 	industrycat10=10 if  (pufc16_pkb>=91 & pufc16_pkb<=99) // to other
+	replace 	industrycat10=10 if industrycat10==. & pufc16_pkb!=.
+
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1061,7 +1083,7 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_>
-	gen 			occup_orig = c16_proc
+	gen 			occup_orig = pufc14_procc
 	label var 		occup_orig "Original occupation record primary job 7 day recall"
 	replace 		occup_orig=. if lstatus!=1 			// restrict universe to employed only
 	replace 		occup_orig=. if age < minlaborage	// restrict universe to working age
@@ -1069,7 +1091,7 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-	loc matchvar   	c16_proc
+	loc matchvar   	pufc14_procc
 	loc n 			1
 
 	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1086,36 +1108,37 @@ foreach v of local ed_var {
 
 	// merge sub-module with isco key
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
 				, format(`"%02.0f"') replace
 
 	merge 		m:1 ///
-				psoc92 ///
+				psic_2dig ///
 				using `isco_key' ///
 				, generate(isco_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
 
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
+	rename 		isco08_2dig_pad	isco08_2dig_`n'
 
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco = isco88_sub_major_`n'
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco08_2dig_`n'
 	label var 	occup_isco "ISCO code of primary job 7 day recall"
 
 *</_occup_isco_>
 
 
 *<_occup_>
-	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	* in 2018, raw variable is numeric 2 digits only
+	/* in 2018, raw variable is numeric
+	Since there are sparse factor labels,
+	that I will have to recode these when issue #18 is resolved https://github.com/worldbank/gld/issues/18
+	I am making many temporary assumptions when I'm recoding here.*/
 
-	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
-	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
-	   and that these occupations cannot be matched to our classificaitons with certainty, I have coded them as "other" */
+	* generate occupation variable
+	gen byte occup=floor(pufc14_procc/10)							// this handles most of recoding automatically.
+	recode occup 0 = 10	if 	(pufc14_procc >=1 & pufc14_procc <=3)	// recode "armed forces" to appropriate label
+
 
 	label var 		occup "1 digit occupational classification, primary job 7 day recall"
 	la de 			lbloccup 	///
@@ -1128,6 +1151,7 @@ foreach v of local ed_var {
 					9 "Elementary occupations" ///
 					10 "Armed forces"  ///
 					99 "Others"
+
 	label values 	occup lbloccup
 	replace 		occup=. if lstatus!=1 		// restrict universe to employed only
 	replace 		occup=. if age < minlaborage	// restrict universe to working age
@@ -1146,7 +1170,7 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_>
-	gen 			double wage_no_compen = c27_pbsc
+	gen 			double wage_no_compen = pufc25_pbasic
 	replace 		wage_no_compen = . if 	wage_no_compen == 99999
 	label var 		wage_no_compen "Last wage payment primary job 7 day recall"
 *</_wage_no_compen_>
@@ -1173,7 +1197,7 @@ foreach v of local ed_var {
 
 
 *<_whours_>
-	gen whours 		= c22_phrs
+	gen whours 		= pufc19_phours
 	label var whours "Hours of work in last week primary job 7 day recall"
     replace 		whours = 84 	if whours > 84 & whours != . 	// replace unrealistic work weeks
 *</_whours_>
@@ -1248,7 +1272,7 @@ foreach v of local ed_var {
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
 /*
-2010 has no secondary job information.
+2018 has no secondary job information.
 */
 
 {
@@ -1267,64 +1291,24 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_2_>
-	gen 			industry_orig_2 = j03_okb
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			industry_orig_2 = .
 	label var 		industry_orig_2 "Original survey industry code, secondary job 7 day recall"
 *</_industry_orig_2_>
 
 
 *<_industrycat_isic_2_>
-	loc matchvar   	j03_okb
-	loc n 			2
-
-	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc isicvar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if industry_orig is numeric)
-			tostring industry_orig_2	///						// make the numeric vars strings
-				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
-				force //
-		}
+	gen 			industrycat_isic_2 = .
+	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 
 
-	// merge sub-module with isic key
-
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psic_2dig ///
-				using `isic_key' ///
-				, generate(isic_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-				* the string variable in isic4 will is industrycat_isic
-
-	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
-
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
-
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
-	gen byte 		industrycat10_2 = .
-
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
-
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+	gen byte 			industrycat10_2 = .
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
 *</_industrycat10_2_>
@@ -1339,45 +1323,18 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_2_>
-	gen 			occup_orig_2 = j02_otoc
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			occup_orig_2 = .
 	label var 		occup_orig_2 "Original occupation record secondary job 7 day recall"
 *</_occup_orig_2_>
 
 
 *<_occup_isco_2_>
-	loc matchvar   	j02_otoc
-	loc n 			2
-
-	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc iscovar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if occup_orig is numeric)
-			tostring occup_orig_2	///						// make the numeric vars strings
-				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
-				force
-		}
-
-
-	// merge sub-module with isco key
-
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psoc92 ///
-				using `isco_key' ///
-				, generate(isco_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-
-
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
-
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco_2 = isco88_sub_major_`n'
+	gen occup_isco_2 = ""
 	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
+
+
 *</_occup_isco_2_>
 
 
@@ -1390,10 +1347,9 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
-							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen byte occup_2 = .
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup
@@ -1401,14 +1357,14 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen 			double wage_no_compen_2 = c36_obic
+	gen 			double wage_no_compen_2 = .
 	replace 		wage_no_compen_2 = . if wage_no_compen_2 == 99999
 	label var 		wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obis
+	gen byte 		unitwage_2 = .
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly
@@ -1421,7 +1377,7 @@ foreach v of local ed_var {
 
 
 *<_whours_2_>
-	gen 			whours_2 = j05_ohrs
+	gen 			whours_2 = .
 	label var 		whours_2 "Hours of work in last week secondary job 7 day recall"
 *</_whours_2_>
 
@@ -1938,7 +1894,7 @@ foreach v of local ed_var {
 
 *<_njobs_>
 	*<_njobs_note>
-	* The provided njobs data appears to be inconsistent with data, so I dedicded not to include.
+	* The pufprvided njobs data appears to be inconsistent with data, so I dedicded not to include.
 	*</_njobs_note>
 
 	gen 			njobs = .
@@ -2125,7 +2081,6 @@ quietly{
 *</_% DROP UNUSED LABELS_>
 
 }
-
 
 *<_% DELETE MISSING VARIABLES_>
 

--- a/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v03_A_GLD/Programs/PHL_2019_LFS_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/PHL/PHL_2019_LFS/PHL_2019_LFS_v01_M_v03_A_GLD/Programs/PHL_2019_LFS_v01_M_v03_A_GLD_ALL.do
@@ -4,7 +4,7 @@
 
 /* -----------------------------------------------------------------------
 
-<_Program name_>				PHL_2010_GLD_LFS.do </_Program name_>
+<_Program name_>				PHL_2019_GLD_LFS.do </_Program name_>
 <_Application_>					Stata 15 <_Application_>
 <_Author(s)_>					World Bank Jobs Group </_Author(s)_>
 <_Date created_>				2022-02-17 </_Date created_>
@@ -13,30 +13,31 @@
 
 <_Country_>						Philippines (PHL) </_Country_>
 <_Survey Title_>				Labor Force Survey </_Survey Title_>
-<_Survey Year_>					2010 </_Survey Year_>
+<_Survey Year_>					2019 </_Survey Year_>
 <_Study ID_>					[Microdata Library ID if present] </_Study ID_>
-<_Data collection from_>		[01/2010] </_Data collection from_>
-<_Data collection to_>			[10/2010] </_Data collection to_>
+<_Data collection from_>		[01/2019] </_Data collection from_>
+<_Data collection to_>			[10/2019] </_Data collection to_>
 <_Source of dataset_> 			[Source of data, e.g. NSO] </_Source of dataset_>
 <_Sample size (HH)_> 			39274 </_Sample size (HH)_>
 <_Sample size (IND)_> 			202742 </_Sample size (IND)_>
-<_Sampling method_> 			Geographic regions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
-<_Geographic coverage_> 		1st-level Subdivision (Region) </_Geographic coverage_>
+<_Sampling method_> 			Geographic pufregions divided into PSUs of ~100-400 Households for further processing </_Sampling method_>
+<_Geographic coverage_> 		1st-level Subdivision (pufregion) </_Geographic coverage_>
 <_Currency_> 					[Currency used for wages] </_Currency_>
 
 -----------------------------------------------------------------------
 
 <_ICLS Version_>				ICLS-13 </_ICLS Version_>
 <_ISCED Version_>				[Version of ICLS for Labor Questions] </_ISCED Version_>
-<_ISCO Version_>				ISCO 88 </_ISCO Version_>
-<_OCCUP National_>				PSOC 92 </_OCCUP National_>
-<_ISIC Version_>				ISIC 3.1 </_ISIC Version_>
-<_INDUS National_>				PSIC 94 </_INDUS National_>
+<_ISCO Version_>				ISCO 08 </_ISCO Version_>
+<_OCCUP National_>				PSOC 12 </_OCCUP National_>
+<_ISIC Version_>				ISIC 4 </_ISIC Version_>
+<_INDUS National_>				PSIC 2009 </_INDUS National_>
 
 -----------------------------------------------------------------------
 <_Version Control_>
 
 Unitwage was coded as per payment period not wage_non_compen timeframe
+* Date: [2022-08-31] File: [As in Program name above] - [Update PSIC-ISIC 09 key; occup_skill only keeps three categories and others were recoded to missing]
 
 </_Version Control_>
 
@@ -67,7 +68,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 ** DIRECTORY
 
 	local 	cty3 	"PHL" 			// set this to the three letter country/economy abbreviation
-	local 	surv_yr  = 2010			// set this to the survey year
+	local 	surv_yr  = 2019			// set this to the survey year
 
 ** RUN SETTINGS
 	local 	cb_pause = 0		// 1 to pause+edit the exported codebook for harmonizing varnames, else 0
@@ -79,30 +80,33 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 	local 	main		"`year'\\`cty3'_`surv_yr'_LFS_v01_M"
 	local 	 stata		"`main'\Data\Stata"
-	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD"
+	local 	gld 		"`year'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD"
 	local 	 code 		"`gld'\Programs"
 	local 	 gld_data 	"`gld'\Data\Harmonized"
 
 	local 	lb_mod_age	15	// labor module minimun age (inclusive)
 	local 	ed_mod_age	5	// labor module minimun age (inclusive)
 
-	local 	weightvar 	fwgt // final weightvar
+	local 	weightvar 	pufpwgtprv // final weightvar
+
+** LOG FILE
+	log using `"`gld_data'\\`cty3'_`surv_yr'_I2D2_LFS.log"', replace
 
 
 ** FILES
 	* input
-	local round1 `"`stata'\LFS JAN2010.dta"'
-	local round2 `"`stata'\LFS APR2010.dta"'
-	local round3 `"`stata'\LFS JUL2010.dta"'
-	local round4 `"`stata'\LFS OCT2010.dta"'
+	local round1 `"`stata'\LFS JAN2019.dta"'
+	local round2 `"`stata'\LFS APR2019.dta"'
+	local round3 `"`stata'\LFS JUL2019.dta"'
+	local round4 `"`stata'\LFS OCT2019.dta"'
 
-	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_94_key_2dig.dta"'
-	local isco_key 	 `"`stata'\PHL_PSOC92_ISCO88_08_key.dta"'
+	local isic_key 	 `"`stata'\PHL_PSIC_ISIC_09_key_2dig_updated.dta"'
+	local isco_key 	 `"`stata'\PHL_PSOC_ISCO_12_key_2dig.dta"'
 
     local adm2_labs	 `"`stata'\GLD_PHL_admin2_labels.dta"'
 
 * ouput
-	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v02_A_GLD_ALL.dta"'
+	local path_output `"`gld_data'\\`cty3'_`surv_yr'_LFS_v01_M_v03_A_GLD_ALL.dta"'
 
 ** VALUES
 	local n_round 	4			// numer of survey rounds
@@ -118,7 +122,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 	iecodebook append ///
 		`"`round1'"' `"`round2'"' `"`round3'"' `"`round4'"' /// survey files
 		using `"`stata'\\`cty3'_`surv_yr'_append_template-IN.xlsx"' /// output just created above
-		, clear surveys(JAN2010 APR2010 JUL2010 OCT2010) generate(round) // survey names
+		, clear surveys(JAN2019 APR2019 JUL2019 OCT2019) generate(round) // survey names
 
 
 /*%%=============================================================================================
@@ -157,13 +161,13 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_isco_version_>
-	gen isco_version = "isco_1988"
+	gen isco_version = "isco_2008"
 	label var isco_version "Version of ISCO used"
 *</_isco_version_>
 
 
 *<_isic_version_>
-	gen isic_version = "isic_3.1"
+	gen isic_version = "isic_4"
 	label var isic_version "Version of ISIC used"
 *</_isic_version_>
 
@@ -181,7 +185,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_veralt_>
-	gen veralt = "v02"
+	gen veralt = "v03"
 	label var veralt "Version of the alt/harmonized data"
 *</_veralt_>
 
@@ -199,7 +203,7 @@ local user_commands ietoolkit scores missings mdesc iefieldkit  //Fill this list
 
 
 *<_int_month_>
-	gen  int_month = svymo
+	gen  int_month = pufsvymo
 	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
 	label value int_month lblint_month
 	label var int_month "Month of the interview"
@@ -221,8 +225,8 @@ replace int_month = 10 	if round == 4
 	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
 	002, ..., 160.
 
-	Since individual Household ID variables were not always provided for the Philippines, yet the household
-	line number variables were provided, it was possible to approximate the household groupings by other variables.
+	Since individual Household ID variables were not always pufprvided for the Philippines, yet the household
+	line number variables were pufprvided, it was possible to approximate the household groupings by other variables.
 	However, this process was not perfectly clean, so checks for duplicates were needed. Please refer to the
 	"Household_IDs.md" in Guides and Documentation for additional explanation. The two variables, hhid and pid
 	will be produced in conjunction, the labelled in the html brackets.
@@ -230,10 +234,9 @@ replace int_month = 10 	if round == 4
 </_hhid_note> */
 ** HOUSEHOLD IDENTIFICATION NUMBER
 
-** HOUSEHOLD IDENTIFICATION NUMBER
 
 
-	loc idhvars 	hhnum   							// store idh vars in local
+	loc idhvars 	pufhhnum   							// store idh vars in local
 
 
 	ds `idhvars',  	has(type numeric)					// filter out numeric variables in local
@@ -277,7 +280,7 @@ replace int_month = 10 	if round == 4
 	* 	note, assuming that the only necessary individaul identifier is family member, which is numeric
 	*	so, not following processing for sorting numeric/non-numeric variables.
 
-	loc idpvars 	c101_lno 							// store relevant idp vars in local
+	loc idpvars 	pufc01_lno 							// store relevant idp vars in local
 	ds `idpvars',  	has(type numeric)					// filter out numeric variables in local
 	loc rlist 		= r(varlist)						// store numeric vars in local
 
@@ -320,15 +323,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_weight_>
-	rename 	weight weight_orig
-	gen 		weight = fwgt / 4
+	gen 		weight = pufpwgtprv / 4
 	label 		var weight "Household sampling weight"
 *</_weight_>
 
 
 *<_psu_>
-	rename 		psu psu_orig
-	gen 		psu = psu_orig
+	gen 		psu = pufpsu
 	label 		var psu "Primary sampling units"
 *</_psu_>
 
@@ -340,7 +341,8 @@ replace int_month = 10 	if round == 4
 
 
 *<_strata_>
-	gen strata = stratum
+	* no explicit strata variable given in 2019
+	gen strata = .
 	label var strata "Strata"
 *</_strata_>
 
@@ -367,7 +369,7 @@ replace int_month = 10 	if round == 4
 
 *<_urban_>
 	gen byte 		urban = .
-	replace 		urban = urb2k70
+	replace 		urban = pufurb2k10
 	recode 			urban (2 = 0) 		// change rural=2 to rural=0
 	label var 		urban "Location is urban"
 	la de 			lblurban 1 "Urban" 0 "Rural"
@@ -381,7 +383,7 @@ replace int_month = 10 	if round == 4
 	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
 
 </_subnatid1> */
-	gen byte 		subnatid1 = reg
+	gen byte 		subnatid1 = pufreg
 	label de 		lblsubnatid1 	///
 					 1   "1 - Ilocos"			///
 					 2	 "2 - Cagayan Valley"	///
@@ -395,12 +397,12 @@ replace int_month = 10 	if round == 4
 					 10  "10 - Northern Mindanao"	///
 					 11  "11 - Davao"	///
 					 12  "12 - Soccsksargen"		///
-					 13  "13 - National Capital Region"				///
-					 14  "14 - Cordillera Administrative Region"		///
-					 15  "15 - Autonomous Region of Muslim Mindanao"	///
+					 13  "13 - National Capital pufregion"				///
+					 14  "14 - Cordillera Administrative pufregion"		///
+					 15  "15 - Autonomous pufregion of Muslim Mindanao"	///
 					 16  "16 - Caraga" ///
 					 /// value 17 exists only in raw data, not in recoded version
-					 18  "18 - Negros Island Region" /// this region appears occasionally in data
+					 18  "18 - Negros Island pufregion" /// this pufregion appears occasionally in data
 				 	 							///
 				 	 41	 "41 - Calabarzon"	/// formerly part of Southern Tagalog
 				 	 42  "42 - Mimaropa"		// formerly part of Southern Tagalog
@@ -440,7 +442,8 @@ replace int_month = 10 	if round == 4
 	}
 
 	// generate the variable and apply the labels.
-	gen byte 		subnatid2 = prov
+	* for 2019, no province variable
+	gen byte 		subnatid2 = .
 	label values 	subnatid2 lblsubnatid2
 	label var 		subnatid2 "Subnational ID at Second Administrative Level"
 
@@ -511,7 +514,7 @@ replace int_month = 10 	if round == 4
 
 *<_hsize_>
 	sort hhid
-	by hhid: egen hsize= count(c05_rel <= 8 | c05_rel == 11) // includes non-family members, not boarders or domestic workers.
+	by hhid: egen hsize= count(pufc03_rel <= 8 | pufc03_rel == 11) // includes non-family members, not boarders or domestic workers.
 	label var 	hsize "Household size"
 
 	* check
@@ -522,14 +525,14 @@ replace int_month = 10 	if round == 4
 
 
 *<_age_>
-	gen 		age = c07_age
+	gen 		age = pufc05_age
 	replace 	age	= 98 	if age>=98 & age!=.
 	label var 	age "Individual age"
 *</_age_>
 
 
 *<_male_>
-	gen 		male = c06_sex
+	gen 		male = pufc04_sex
 	recode 		male (2 = 0)						// female=2 recoded to female=0
 	label var 	male "Sex - Ind is male"
 	la de 		lblmale 	1 "Male" 0 "Female"
@@ -539,7 +542,7 @@ replace int_month = 10 	if round == 4
 
 *<_relationharm_>
 	gen 		relationharm = .
-	replace 	relationharm = c05_rel
+	replace 	relationharm = pufc03_rel
 	recode 		relationharm (4 5 6 8  	= 5) /// siblings, children in law, grandchildren, other rel of hh head="other relatives"
 					(7 			= 4)	/// parents of hh head become "parents"
 					(9 10 11 	= 6) 	// boarders and domestic workers become "other/non-relatives"
@@ -566,13 +569,13 @@ replace int_month = 10 	if round == 4
 
 
 *<_relationcs_>
-	gen relationcs = c05_rel
+	gen relationcs = pufc03_rel
 	label var relationcs "Relationship to the head of household - Country original"
 *</_relationcs_>
 
 
 *<_marital_>
-	gen byte 		marital = c08_ms
+	gen byte 		marital = pufc06_mstat
 	recode 			marital 	///
 					(1=2) 	///	"single" -> "never married"
 					(2=1) /// "married" -> "married"
@@ -717,7 +720,7 @@ label var ed_mod_age "Education module application age"
 *</_ed_mod_age_>
 
 *<_school_>
-	gen byte school= a02_csch
+	gen byte school= pufc08_cursch
 	recode school (2 = 0)		// 2 was "no", recode to 0. Keep 1=Yes same.
 	label var school "Attending school"
 	la de lblschool 0 "No" 1 "Yes"
@@ -740,19 +743,40 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat7_>
-	/*Please refer to the "Education_Levels.md" for a detailed discussion on
-	classificition of how each level is classified and why,
-	available in github repository. */
+	/*Please refer to the "Education_Levels.md" for a detailed discussion on classificition of how each level is classified and why,
+		available in github repository. */
 
-	gen byte educat7 =.
+	gen byte educat7=.
+	replace educat7=1 if pufc07_grade <= 2000 		// less than primary to "no education"
+
+	replace educat7=2 if pufc07_grade == 10010 		/// Grade 1-5 -> "primary incomplete" (april)
+							| pufc07_grade == 10002 	/// also include SPED + continuing education as codebook specifies
+							| pufc07_grade == 10003
+
+	replace educat7=3 if pufc07_grade == 10020 		// grade 6/7 graduate to "primary complete"
+
+	replace educat7=4 if pufc07_grade == 24010 		/// grade 7-9
+							| pufc07_grade == 24020 	/// and grade 10 -> "secondary incomplete "
+							| pufc07_grade == 34011 	/// and grades 11 -> "secondary incomplete"
+							| pufc07_grade == 34021 	///
+							| pufc07_grade == 35001  	/// also include SPEC and continuing education as codebook specifies
+							| pufc07_grade == 24002 	///
+							| pufc07_grade == 24003
+
+	replace educat7=5 if pufc07_grade == 34012 		/// all grade 12 courses -> to "secondary complete"
+							| pufc07_grade == 34022 	///
+							| pufc07_grade == 34032 	///
+							| pufc07_grade == 35002
+
+ 	replace educat7=6 if (pufc07_grade >= 40000 & pufc07_grade <= 59999) 	// post-secondary but not uni
+	replace educat7=7 if (pufc07_grade >= 60000 & pufc07_grade <= 89999) // all current university and advanced degree students + grads
+	replace educat7=3 if    pufc07_grade == 24002
+	*There's no documentation on where to classify SPED and no grade distinction, so classify as Primary Complete as most conservative.
 
 
-	replace educat7=1 if c09_grd==0			// "No Grade Completed" -> "No education"
-	replace educat7=2 if c09_grd==1 	// "Elementary Undergraduate" -> " Primary Incomplete"
-	replace educat7=3 if c09_grd==2 	// "Elementary Graduate" -> "Primary Complete"
-	replace educat7=4 if c09_grd==3		// "High School Undergraduate" -> "Secondary Incomplete"
-	replace educat7=5 if c09_grd==4		// "High school graduate" -> "Secondary Complete"
-	replace educat7=7 if c09_grd==5 | ( c09_grd>=60 & c09_grd<=98) // "College Graduate" and "[x] Bachelors/Advanced Degree" -> "University"
+	* for 2019, replace educat7 == missing if the rounds/month is July or October.
+	* this is because there is not enough information for these rounds, which differ from the first two.
+	replace educat7=.	if pufsvymo == 7 | pufsvymo == 10 		// if july or october
 
 	label var educat7 "Level of education 1"
 	la de lbleducat7 	1 "No education" ///
@@ -793,7 +817,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = c09_grd
+	gen educat_orig = pufc07_grade
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -881,7 +905,7 @@ foreach v of local ed_var {
 
 {
 *<_lstatus_>
-	gen byte 		lstatus = newempst
+	gen byte 		lstatus = pufnewempstat
 	replace 		lstatus = . if age < minlaborage
 	label var 		lstatus "Labor status"
 	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF" // raw values always same as new
@@ -892,8 +916,8 @@ foreach v of local ed_var {
 *<_potential_lf_>
 	gen byte 		potential_lf = 0
 
-	replace 		potential_lf = 1 if (c37_avil == 1 & c38_lokw == 2) ///
-										| (c37_avil == 2 & c38_lokw == 1)
+	replace 		potential_lf = 1 if (pufc36_avail == 1 & pufc30_lookw == 2) ///
+										| (pufc36_avail == 2 & pufc30_lookw == 1)
 	replace 		potential_lf = . if age < minlaborage & age != .
 	replace 		potential_lf = . if lstatus != 3
 	label var 		potential_lf "Potential labour force status"
@@ -905,7 +929,7 @@ foreach v of local ed_var {
 *<_underemployment_>
 	gen byte 		underemployment = 0
 
-	replace 		underemployment = 1 if c23_pwmr == 1
+	replace 		underemployment = 1 if pufc20_pwmore == 1
 	replace 		underemployment = . if age < minlaborage & age != .
 	replace 		underemployment = . if lstatus != 1
 	label var 		underemployment "Underemployment status"
@@ -916,11 +940,11 @@ foreach v of local ed_var {
 
 *<_nlfreason_>
 	gen byte 		nlfreason= .
-	replace 		nlfreason=1 	if c42_wynt==8
-	replace 		nlfreason=2 	if c42_wynt==7
-	replace 		nlfreason=3 	if c42_wynt==6
-	replace 		nlfreason=4 	if c42_wynt==3
-	replace 		nlfreason=5 	if c42_wynt==1 | c42_wynt==2 | c42_wynt==4 | c42_wynt==5 | c42_wynt==9
+	replace 		nlfreason=1 	if pufc34_wynot==8
+	replace 		nlfreason=2 	if pufc34_wynot==7
+	replace 		nlfreason=3 	if pufc34_wynot==6
+	replace 		nlfreason=4 	if pufc34_wynot==3
+	replace 		nlfreason=5 	if pufc34_wynot==1 | pufc34_wynot==2 | pufc34_wynot==4 | pufc34_wynot==5 | pufc34_wynot==9
 	replace 		nlfreason=. 	if lstatus!=3 		// restricts universe to non-labor force
 	label var 		nlfreason "Reason not in the labor force"
 	la de 			lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
@@ -929,7 +953,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_l_>
-	gen byte 		unempldur_l=c40_wks/4.2
+	gen byte 		unempldur_l=pufc33_weeks/4.2
 	label var 		unempldur_l "Unemployment duration (months) lower bracket"
 	replace 		unempldur_l=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -937,7 +961,7 @@ foreach v of local ed_var {
 
 
 *<_unempldur_u_>
-	gen byte 		unempldur_u=c40_wks/4.2
+	gen byte 		unempldur_u=pufc33_weeks/4.2
 	label var 		unempldur_u "Unemployment duration (months) upper bracket"
 	replace 		unempldur_u=. if lstatus!=2 	  // restrict universe to unemployed only
 
@@ -951,10 +975,10 @@ foreach v of local ed_var {
 {
 *<_empstat_>
 	gen byte 		empstat=.
-	replace 		empstat=1 	if c19pclas==0 | c19pclas==1 | c19pclas==2 | c19pclas==5
-	replace 		empstat=2 	if c19pclas==6
-	replace 		empstat=3	if c19pclas==4
-	replace 		empstat=4 	if c19pclas==3
+	replace 		empstat=1 	if pufc23_pclass==0 | pufc23_pclass==1 | pufc23_pclass==2 | pufc23_pclass==5
+	replace 		empstat=2 	if pufc23_pclass==6
+	replace 		empstat=3	if pufc23_pclass==4
+	replace 		empstat=4 	if pufc23_pclass==3
 	replace 		empstat=. 	if lstatus!=1 	// includes universe restriction
 	label var 		empstat 	"Employment status during past week primary job 7 day recall"
 	la de 			lblempstat 	1 "Paid employee" ///
@@ -968,8 +992,8 @@ foreach v of local ed_var {
 
 *<_ocusec_>
 	gen byte 		ocusec = .
-	replace 		ocusec = 1 	if c19pclas == 2
-	replace 		ocusec = 2 	if inlist(c19pclas, 0, 1, 3, 4, 5, 6)
+	replace 		ocusec = 1 	if pufc23_pclass == 2
+	replace 		ocusec = 2 	if inlist(pufc23_pclass, 0, 1, 3, 4, 5, 6)
 
 	label var 		ocusec 		"Sector of activity primary job 7 day recall"
 	la de 			lblocusec 	1 "Public Sector, Central Government, Army" ///
@@ -981,18 +1005,15 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_>
-	gen 			industry_orig = c18_pkb
+	gen 			industry_orig = pufc16_pkb
 	label var 		industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 
 
 *<_industrycat_isic_>
-	loc matchvar   	c18_pkb
+	loc matchvar   	pufc16_pkb
 	loc n 			1
 
-	qui ds 			industry_orig, has(type numeric) 	// capture numeric var if is numeric
-	loc isicvar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
 
 		if (`len' == 1) {
 															// run this if == 1 (ie, if industry_orig is numeric)
@@ -1016,27 +1037,30 @@ foreach v of local ed_var {
 				* the string variable in isic4 will is industrycat_isic
 
 	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
+	rename 		isic4_2dig_pad	isic4_2dig_`n'
 
-	gen 		industrycat_isic = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
+	gen 		industrycat_isic = isic4_2dig_`n'  	// the string variable becomes industrycat_isic
 
 	drop 		psic_2dig 				// no longer needed, maintained in matchvar
 	label var 	industrycat_isic "ISIC code of primary job 7 day recall"
-*</_industrycat_isic_>
+	*</_industrycat_isic_>
 
 
 *<_industrycat10_>
-	gen byte 		industrycat10=.
-	replace 		industrycat10=1 if c18_pkb >= 1 & c18_pkb <= 9		// Agriculture
-	replace 		industrycat10=2 if c18_pkb == 10 | c18_pkb == 11		// Mining
-	replace 		industrycat10=3 if c18_pkb>=15 & c18_pkb <= 39		// Manufacturing
-	replace 		industrycat10=4 if c18_pkb==40 | c18_pkb==41			// Public Utility Services
-	replace 		industrycat10=5 if c18_pkb==45						// Construction
-	replace 		industrycat10=6 if c18_pkb >= 50 & c18_pkb <= 55		// Commerce
-	replace 		industrycat10=7 if c18_pkb >= 60 & c18_pkb <= 64		// Transport + Communication
-	replace 		industrycat10=8 if c18_pkb >= 65 & c18_pkb <= 74		// Financial + Business Services
-	replace 		industrycat10=9 if c18_pkb == 75						// Public Administration
-	replace 		industrycat10=10 if c18_pkb>=76 & c18_pkb <= 99 		// this includes education/teaching.
+	gen byte industrycat10=.
+
+	replace 	industrycat10=1 if (pufc16_pkb>=1 & pufc16_pkb<=4)		// to Agriculture
+	replace 	industrycat10=2 if (pufc16_pkb>=5 & pufc16_pkb<=9)		// to Mining
+	replace 	industrycat10=3 if (pufc16_pkb>=10 & pufc16_pkb<=33)	// to Manufacturing
+	replace 	industrycat10=4 if (pufc16_pkb>=35 & pufc16_pkb<=39)	// to Public utility
+	replace 	industrycat10=5 if (pufc16_pkb>=41 &  pufc16_pkb<=43)	// to Construction
+	replace 	industrycat10=6 if (pufc16_pkb>=45 & pufc16_pkb<=47) | (pufc16_pkb>=55 & pufc16_pkb<=56)	// to Commerce
+	replace 	industrycat10=7 if (pufc16_pkb>=49 & pufc16_pkb<=53) | (pufc16_pkb>=58 & pufc16_pkb<=63) // to Transport/coms
+	replace 	industrycat10=8 if (pufc16_pkb>=64 & pufc16_pkb<=82) 	// to financial/business services
+	replace 	industrycat10=9 if (pufc16_pkb==84) 				// to public administration
+	replace 	industrycat10=10 if  (pufc16_pkb>=91 & pufc16_pkb<=99) // to other
+	replace 	industrycat10=10 if industrycat10==. & pufc16_pkb!=.
+
 
 	label var 		industrycat10 "1 digit industry classification, primary job 7 day recall"
 	la de 			lblindustrycat10 	///
@@ -1061,7 +1085,7 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_>
-	gen 			occup_orig = c16_proc
+	gen 			occup_orig = pufc14_procc
 	label var 		occup_orig "Original occupation record primary job 7 day recall"
 	replace 		occup_orig=. if lstatus!=1 			// restrict universe to employed only
 	replace 		occup_orig=. if age < minlaborage	// restrict universe to working age
@@ -1069,7 +1093,7 @@ foreach v of local ed_var {
 
 
 *<_occup_isco_>
-	loc matchvar   	c16_proc
+	loc matchvar   	pufc14_procc
 	loc n 			1
 
 	qui ds 			occup_orig, has(type numeric) 	// capture numeric var if is numeric
@@ -1086,36 +1110,37 @@ foreach v of local ed_var {
 
 	// merge sub-module with isco key
 
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
+	gen psic_2dig = `matchvar'
+	tostring 	psic_2dig ///
 				, format(`"%02.0f"') replace
 
 	merge 		m:1 ///
-				psoc92 ///
+				psic_2dig ///
 				using `isco_key' ///
 				, generate(isco_merge_`n') ///
 				keep(master match) // "left join"; remove obs that don't match from using
 
 
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
+	rename 		isco08_2dig_pad	isco08_2dig_`n'
 
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco = isco88_sub_major_`n'
+	drop 		psic_2dig 				// no longer needed, maintained in matchvar
+	gen 		occup_isco = isco08_2dig_`n'
 	label var 	occup_isco "ISCO code of primary job 7 day recall"
 
 *</_occup_isco_>
 
 
 *<_occup_>
-	* generate occupation variable
-	gen byte 		occup = floor(c16_proc/10)		// this handles most of recoding automatically.
-	recode 			occup 0 = 10	if 	c16_proc==1 	// recode "armed forces" to appropriate label
-	recode 			occup 0 = 99	if 	(c16_proc>=2 & c16_proc <=9) ///
-							| 		(c16_proc >=94 & c16_proc <= 99) // recode "Not classifiable occupations"
+	* in 2019, raw variable is numeric 2 digits only
+	/* in 2019, raw variable is numeric
+	Since there are sparse factor labels,
+	that I will have to recode these when issue #18 is resolved https://github.com/worldbank/gld/issues/18
+	I am making many temporary assumptions when I'm recoding here.*/
 
-	/* Note that the raw variable, procc lists values, 94-99 for which there are no associated occupation
-	   codes. Given that the raw data indicate that these individauls do have valid, non-missing occupations,
-	   and that these occupations cannot be matched to our classificaitons with certainty, I have coded them as "other" */
+	* generate occupation variable
+	gen byte occup=floor(pufc14_procc/10)							// this handles most of recoding automatically.
+	recode occup 0 = 10	if 	(pufc14_procc >=1 & pufc14_procc <=3)	// recode "armed forces" to appropriate label
+
 
 	label var 		occup "1 digit occupational classification, primary job 7 day recall"
 	la de 			lbloccup 	///
@@ -1128,6 +1153,7 @@ foreach v of local ed_var {
 					9 "Elementary occupations" ///
 					10 "Armed forces"  ///
 					99 "Others"
+
 	label values 	occup lbloccup
 	replace 		occup=. if lstatus!=1 		// restrict universe to employed only
 	replace 		occup=. if age < minlaborage	// restrict universe to working age
@@ -1146,7 +1172,7 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_>
-	gen 			double wage_no_compen = c27_pbsc
+	gen 			double wage_no_compen = pufc25_pbasic
 	replace 		wage_no_compen = . if 	wage_no_compen == 99999
 	label var 		wage_no_compen "Last wage payment primary job 7 day recall"
 *</_wage_no_compen_>
@@ -1173,7 +1199,7 @@ foreach v of local ed_var {
 
 
 *<_whours_>
-	gen whours 		= c22_phrs
+	gen whours 		= pufc19_phours
 	label var whours "Hours of work in last week primary job 7 day recall"
     replace 		whours = 84 	if whours > 84 & whours != . 	// replace unrealistic work weeks
 *</_whours_>
@@ -1248,7 +1274,7 @@ foreach v of local ed_var {
 *----------8.3: 7 day reference secondary job------------------------------*
 * Since labels are the same as main job, values are labelled using main job labels
 /*
-2010 has no secondary job information.
+2019 has no secondary job information.
 */
 
 {
@@ -1267,64 +1293,24 @@ foreach v of local ed_var {
 
 
 *<_industry_orig_2_>
-	gen 			industry_orig_2 = j03_okb
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			industry_orig_2 = .
 	label var 		industry_orig_2 "Original survey industry code, secondary job 7 day recall"
 *</_industry_orig_2_>
 
 
 *<_industrycat_isic_2_>
-	loc matchvar   	j03_okb
-	loc n 			2
-
-	qui ds 			industry_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc isicvar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof isicvar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if industry_orig is numeric)
-			tostring industry_orig_2	///						// make the numeric vars strings
-				, generate(industry_orig_2_str) ///			// gen a variable with this prefix
-				force //
-		}
+	gen 			industrycat_isic_2 = .
+	label var 		industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 
 
-	// merge sub-module with isic key
-
-	gen psic_2dig = `matchvar'
-	tostring 	psic_2dig ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psic_2dig ///
-				using `isic_key' ///
-				, generate(isic_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-				* the string variable in isic4 will is industrycat_isic
-
-	// replace one code that I know doesn't match
-	rename 		isic3_1_2dig_pad	isic3_1_2dig_`n'
-
-	gen 		industrycat_isic_2 = isic3_1_2dig_`n'  	// the string variable becomes industrycat_isic
-
-	drop 		psic_2dig 				// no longer needed, maintained in matchvar
-	label var 	industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
-	gen byte 		industrycat10_2 = .
-
-	replace 		industrycat10_2=1 if j03_okb >= 1 & j03_okb <= 9		// Agriculture
-	replace 		industrycat10_2=2 if j03_okb == 10 | j03_okb == 11		// Mining
-	replace 		industrycat10_2=3 if j03_okb>=15 & j03_okb <= 39		// Manufacturing
-	replace 		industrycat10_2=4 if j03_okb==40 | j03_okb==41			// Public Utility Services
-	replace 		industrycat10_2=5 if j03_okb==45						// Construction
-	replace 		industrycat10_2=6 if j03_okb >= 50 & j03_okb <= 55		// Commerce
-	replace 		industrycat10_2=7 if j03_okb >= 60 & j03_okb <= 64		// Transport + Communication
-	replace 		industrycat10_2=8 if j03_okb >= 65 & j03_okb <= 74		// Financial + Business Services
-	replace 		industrycat10_2=9 if j03_okb == 75						// Public Administration
-	replace 		industrycat10_2=10 if j03_okb>=76 & j03_okb <= 99 		// this includes education for now.
-
+/*no second industry variable given (the given one is for previous quarter not for second job)*/
+	gen byte 			industrycat10_2 = .
 	label var 		industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values 	industrycat10_2 lblindustrycat10
 *</_industrycat10_2_>
@@ -1339,45 +1325,18 @@ foreach v of local ed_var {
 
 
 *<_occup_orig_2_>
-	gen 			occup_orig_2 = j02_otoc
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen 			occup_orig_2 = .
 	label var 		occup_orig_2 "Original occupation record secondary job 7 day recall"
 *</_occup_orig_2_>
 
 
 *<_occup_isco_2_>
-	loc matchvar   	j02_otoc
-	loc n 			2
-
-	qui ds 			occup_orig_2, has(type numeric) 	// capture numeric var if is numeric
-	loc iscovar 	= r(varlist)						// store this in a local
-	loc len 		: list sizeof iscovar 				// store the length of this local (1 or 0)
-
-		if (`len' == 1) {
-															// run this if == 1 (ie, if occup_orig is numeric)
-			tostring occup_orig_2	///						// make the numeric vars strings
-				, generate(occup_orig_2_str) ///			// gen a variable with this prefix
-				force
-		}
-
-
-	// merge sub-module with isco key
-
-	gen psoc92 = `matchvar'
-	tostring 	psoc92 ///
-				, format(`"%02.0f"') replace
-
-	merge 		m:1 ///
-				psoc92 ///
-				using `isco_key' ///
-				, generate(isco_merge_`n') ///
-				keep(master match) // "left join"; remove obs that don't match from using
-
-
-	rename 		isco88_sub_major_pad	isco88_sub_major_`n'
-
-	drop 		psoc92 				// no longer needed, maintained in matchvar
-	gen 		occup_isco_2 = isco88_sub_major_`n'
+	gen occup_isco_2 = "" // occup_isco already generated above in submodule
 	label var 	occup_isco_2 "ISCO code of secondary job 7 day recall"
+
+
 *</_occup_isco_2_>
 
 
@@ -1390,10 +1349,9 @@ foreach v of local ed_var {
 
 
 *<_occup_2_>
-	gen byte occup_2=floor(j02_otoc/10)		// this handles most of recoding automatically.
-	recode occup_2 0 = 10	if 	j02_otoc==1 	// recode "armed forces" to appropriate label
-	recode occup_2 0 = 99	if 	(j02_otoc>=2 & j02_otoc <=9) ///
-							| (j02_otoc >=94 & j02_otoc <= 99) // recode "Not classifiable occupations"
+/*no second occupation variable given (the given one is for previous quarter not for second job)*/
+
+	gen byte occup_2 = .
 
 	label var 		occup_2 "1 digit occupational classification secondary job 7 day recall"
 	label values 	occup_2 lbloccup
@@ -1401,14 +1359,14 @@ foreach v of local ed_var {
 
 
 *<_wage_no_compen_2_>
-	gen 			double wage_no_compen_2 = c36_obic
+	gen 			double wage_no_compen_2 = .
 	replace 		wage_no_compen_2 = . if wage_no_compen_2 == 99999
 	label var 		wage_no_compen_2 "Last wage payment secondary job 7 day recall"
 *</_wage_no_compen_2_>
 
 
 *<_unitwage_2_>
-	gen byte 		unitwage_2 = j06_obis
+	gen byte 		unitwage_2 = .
 	replace 		unitwage_2 = . if 	unitwage >= 11 // replace potential missing values
 	recode 			unitwage_2 (0 1 5 6 7 = 10) /// other
 								(2 = 9) /// hourly
@@ -1421,7 +1379,7 @@ foreach v of local ed_var {
 
 
 *<_whours_2_>
-	gen 			whours_2 = j05_ohrs
+	gen 			whours_2 = .
 	label var 		whours_2 "Hours of work in last week secondary job 7 day recall"
 *</_whours_2_>
 
@@ -1938,7 +1896,7 @@ foreach v of local ed_var {
 
 *<_njobs_>
 	*<_njobs_note>
-	* The provided njobs data appears to be inconsistent with data, so I dedicded not to include.
+	* The pufprvided njobs data appears to be inconsistent with data, so I dedicded not to include.
 	*</_njobs_note>
 
 	gen 			njobs = .


### PR DESCRIPTION
Hi Mario @gronert-m,

PHL is ready for review. Changes include:

- 2001-2011: `occup_skill`  was re-written to drop category 4 and 5 and everything else beyond 1-9 in `occup`
- 2012-2019: in addition to the `occup_skill` above, *ISIC key* file has been updated alt version 03 has been created for all the changes made this time
- 1997-2000: stay the same as they do not have `occup_skill` nor `occup`