### PR TITLE
Update figures in checks

### DIFF
--- a/Support/D - Q Checks/Helper_programs_1.4/B2.05_ext_figA_GLD.do
+++ b/Support/D - Q Checks/Helper_programs_1.4/B2.05_ext_figA_GLD.do
@@ -15,71 +15,60 @@
 ********************************************************************************
 
 *-- 01. Total population
-	use "Block2_External/01_data/01totpop.dta", clear
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/01totpop.dta", clear
+	if _rc == 0 {  // if file create, otherwise don't 
 		
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-	leg(off) ytitle("") xtitle("")  name(Fig1, replace)
-	xlabel(1(1)`c', valuelabel angle(45) labs(small))
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Total population", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig1.pdf", replace	
+		count 
+		local c = `r(N)' 
+			
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+		leg(off) ytitle("") xtitle("")  name(Fig1, replace)
+		xlabel(1(1)`c', valuelabel angle(45) labs(small))
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Total population", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig1.pdf", replace	
+			
+	}
 	
-
+	
 	
 *-- 02. Female share
-	use "Block2_External/01_data/02gensplit.dta", clear 
-	count 
-	local c = `r(N)' 
-	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue) 
-	leg(off) ytitle("") xtitle("") name(Fig2, replace)
-	xlabel(1(1)`c', valuelabel angle(45) labs(small))
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Female share", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig2.pdf", replace		
-	
+	capture use "Block2_External/01_data/02gensplit.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
+		
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue) 
+		leg(off) ytitle("") xtitle("") name(Fig2, replace)
+		xlabel(1(1)`c', valuelabel angle(45) labs(small))
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Female share", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig2.pdf", replace		
+		
+	}
 	
 *-- 03. Urban share 
 	
-	** Determin presence first 
-	use "${mydata}", clear
-	describe, replace
-	count if name == "urban"
+	capture use "Block2_External/01_data/03urbanshare.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
 	
-	if 	`r(N)' == 0 {
-		gen dot =.
-
-		#delimit ;
-		twoway scatter dot dot,
-		leg(off) ytitle("") xtitle("") name(Fig3, replace)
-		xlabel(, valuelabel angle(45) labs(small)) 
-		ylabel( , nogrid angle(horizontal) labs(small))
-		scheme(s2mono) graphregion(fcolor(white) color(white))
-		subtitle("Urban data not available ", position(11) justification(left) size(medsmall));
-		#delimit cr 
-		graph export "Block2_External/02_figures/Fig3.pdf", replace		
-	}
-	else {
-
-		use "Block2_External/01_data/03urbanshare.dta", clear 
 		count 
 		local c = `r(N)' 
 		
@@ -96,31 +85,16 @@
 		scheme(s2mono) graphregion(fcolor(white) color(white))
 		subtitle("Urban share", position(11) justification(left) size(medsmall));
 		#delimit cr 
-		graph export "Block2_External/02_figures/Fig3.pdf", replace		
+		graph export "Block2_External/02_figures/Fig3.pdf", replace	
+	
 	}
 	
+	
 *-- 04. Children %
-	** Determine presence of children
-	use "${mydata}", clear
-	sum age 
 
-	if 	`r(min)' >= 15 {
-		gen dot =.
-		
-			
-		#delimit ;
-		twoway scatter dot dot,
-		leg(off) ytitle("") xtitle("") name(Fig4, replace)
-		xlabel(, valuelabel angle(45) labs(small)) 
-		ylabel( , nogrid angle(horizontal) labs(small))
-		scheme(s2mono) graphregion(fcolor(white) color(white))
-		subtitle("Children data not available ", position(11) justification(left) size(medsmall));
-		#delimit cr 
-		graph export "Block2_External/02_figures/Fig4.pdf", replace	
-	}
-	else {	
-
-		use "Block2_External/01_data/04children.dta", clear 
+	capture use "Block2_External/01_data/04children.dta", clear
+	if _rc == 0 {  // if file create, otherwise don't 
+	
 		count 
 		local c = `r(N)' 
 		
@@ -140,9 +114,13 @@
 		graph export "Block2_External/02_figures/Fig4.pdf", replace		
 	
 	}
+
+
 	
 *-- 05. Working age % 
-	use "Block2_External/01_data/05workingage.dta", clear 
+	capture use "Block2_External/01_data/05workingage.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
+	
 	count 
 	local c = `r(N)' 
 		
@@ -159,11 +137,16 @@
 	scheme(s2mono) graphregion(fcolor(white) color(white))
 	subtitle("Working age 15-64 (%)", position(11) justification(left) size(medsmall));
 	#delimit cr 
-	graph export "Block2_External/02_figures/Fig5.pdf", replace		
+	graph export "Block2_External/02_figures/Fig5.pdf", replace			
+	
+	}
+
 	
 	
 *-- 06. Seniors % 
-	use "Block2_External/01_data/06seniors.dta", clear 
+	capture use "Block2_External/01_data/06seniors.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
+	
 	count 
 	local c = `r(N)' 
 		
@@ -180,16 +163,29 @@
 	scheme(s2mono) graphregion(fcolor(white) color(white))
 	subtitle("Seniors 65+ (%)", position(11) justification(left) size(medsmall));
 	#delimit cr 
-	graph export "Block2_External/02_figures/Fig6.pdf", replace			
+	graph export "Block2_External/02_figures/Fig6.pdf", replace	
 	
+	}
 	
+			
 	
 ********************************************************************************
 *                           02. Combined figure                                *
 ********************************************************************************
 
+	* First sift which graphs where created, store that in local graphs_in_memory
+	local graphs_in_memory 
+	foreach fig in Fig1 Fig2 Fig3 Fig4 Fig5 Fig6 {
+		
+		capture gr describe `fig'
+		if _rc == 0 { // graph actully in memory
+			local graphs_in_memory `graphs_in_memory' `fig'
+		}
+		
+	}
+
 	#delimit;
-	gr combine Fig1 Fig2 Fig3 Fig4 Fig5 Fig6,
+	gr combine `graphs_in_memory',
 	scheme(s2mono) graphregion(fcolor(white) color(white)) c(3)
 	subtitle("Block 2A. Demographic Variables, ${ccode3}", position(11) justification(left) size(medsmall));
 	#delimit cr

--- a/Support/D - Q Checks/Helper_programs_1.4/B2.06_ext_figB1_GLD.do
+++ b/Support/D - Q Checks/Helper_programs_1.4/B2.06_ext_figB1_GLD.do
@@ -15,179 +15,214 @@
 ********************************************************************************
 
 *-- 01. Labor fore size 
-	use "Block2_External/01_data/07labforce.dta", clear 
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/07labforce.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
 	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-	leg(off) ytitle("") xtitle("")  name(Fig7, replace)
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Labor force size", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig7.pdf", replace	
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+		leg(off) ytitle("") xtitle("")  name(Fig7, replace)
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Labor force size", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig7.pdf", replace	
 	
+	}
 	
 *-- 02. Labor force participation rate 
-	use "Block2_External/01_data/08labfpart.dta", clear 
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/08labfpart.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
 	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)  
-	leg(off) ytitle("") xtitle("")  name(Fig8, replace)
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Labor force participation rate", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig8.pdf", replace		
-	
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)  
+		leg(off) ytitle("") xtitle("")  name(Fig8, replace)
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Labor force participation rate", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig8.pdf", replace		
+		
+	}
 	
 *-- 03. Employment number 
-	use "Block2_External/01_data/09employment.dta", clear 
-	count 
-	local c = `r(N)' 
-	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-	leg(off) ytitle("") xtitle("") name(Fig9, replace) 
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Employment (number)", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig9.pdf", replace		
-	
+	capture use "Block2_External/01_data/09employment.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
+		
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+		leg(off) ytitle("") xtitle("") name(Fig9, replace) 
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Employment (number)", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig9.pdf", replace		
+		
+	}
 	
 *-- 04. Employment to population ratio
-	use "Block2_External/01_data/10emptopop.dta", clear 
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/10emptopop.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
 	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-	leg(off) ytitle("") xtitle("") name(Fig10, replace) 
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Employment to population ratio", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig10.pdf", replace	
-	
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+		leg(off) ytitle("") xtitle("") name(Fig10, replace) 
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Employment to population ratio", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig10.pdf", replace	
+		
+	}
 	
 *-- 05. Unemployment rate
-	use "Block2_External/01_data/11unemployment.dta", clear 
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/11unemployment.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
+		
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+		leg(off) ytitle("") xtitle("")  name(Fig11, replace)
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Unemployment rate", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig11.pdf", replace		
+					
+	}			
 	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-	leg(off) ytitle("") xtitle("")  name(Fig11, replace)
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Unemployment rate", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig11.pdf", replace		
-				
-				
 *-- 06. Employment in agriculture 
-	use "Block2_External/01_data/12agriculture.dta", clear 
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/12agriculture.dta", clear
+	if _rc == 0 {  // if file create, otherwise don't 
 	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-	leg(off) ytitle("") xtitle("") name(Fig12, replace) 
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Employment in agriculture (%)", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig12.pdf", replace		
-	
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+		leg(off) ytitle("") xtitle("") name(Fig12, replace) 
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Employment in agriculture (%)", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig12.pdf", replace		
+		
+	}
 	
 *-- 07. Employment in industry
-	use "Block2_External/01_data/13industry.dta", clear 
-	count 
-	local c = `r(N)' 
-	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue) 
-	leg(off) ytitle("") xtitle("")  name(Fig13, replace)
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Employment in industry (%)", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig13.pdf", replace
-	
+	capture use "Block2_External/01_data/13industry.dta", clear 
+	if _rc == 0 {  // if file create, otherwise don't 
+		
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue) 
+		leg(off) ytitle("") xtitle("")  name(Fig13, replace)
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Employment in industry (%)", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig13.pdf", replace
+		
+	}
 	
 *-- 08. Employment in sevices 
-	use "Block2_External/01_data/14services.dta", clear
-	count 
-	local c = `r(N)' 
+	capture use "Block2_External/01_data/14services.dta", clear
+	if _rc == 0 {  // if file create, otherwise don't 
 	
-	#delimit ;
-	twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-	       scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-		   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-		   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-		   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-		   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue) 
-	leg(off) ytitle("") xtitle("") name(Fig14, replace) 
-	xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-	ylabel( , nogrid angle(horizontal) labs(small))
-	scheme(s2mono) graphregion(fcolor(white) color(white))
-	subtitle("Employment in services (%)", position(11) justification(left) size(medsmall));
-	#delimit cr 
-	graph export "Block2_External/02_figures/Fig14.pdf", replace		
-	
+		count 
+		local c = `r(N)' 
+		
+		#delimit ;
+		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue) 
+		leg(off) ytitle("") xtitle("") name(Fig14, replace) 
+		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+		ylabel( , nogrid angle(horizontal) labs(small))
+		scheme(s2mono) graphregion(fcolor(white) color(white))
+		subtitle("Employment in services (%)", position(11) justification(left) size(medsmall));
+		#delimit cr 
+		graph export "Block2_External/02_figures/Fig14.pdf", replace		
+		
+	}
 	
 ********************************************************************************
 *                           02. Combined figure                                *
 ********************************************************************************
 
+	* First sift which graphs where created, store that in local graphs_in_memory
+	local graphs_in_memory 
+	foreach fig in Fig7 Fig9 Fig8 Fig10 Fig11 Fig12 Fig13 Fig14 {
+		
+		capture gr describe `fig'
+		if _rc == 0 { // graph actully in memory
+			local graphs_in_memory `graphs_in_memory' `fig'
+		}
+		
+	}
+	
 	#delimit;
-	gr combine Fig7 Fig9 Fig8 Fig10 Fig11 Fig12 Fig13 Fig14,
+	gr combine `graphs_in_memory',
 	scheme(s2mono) graphregion(fcolor(white) color(white)) c(3) hole(3)
 	subtitle("Block 2B.1. Labor Force Variables, ${ccode3}", position(11) justification(left) size(medsmall));
 	#delimit cr

--- a/Support/D - Q Checks/Helper_programs_1.4/B2.07_ext_figB2_GLD.do
+++ b/Support/D - Q Checks/Helper_programs_1.4/B2.07_ext_figB2_GLD.do
@@ -17,25 +17,29 @@
 *-- 05. Figure (original vs ILO)
 	forvalues j = 1/10 {
 		
-		use "Block2_External/01_data/15industry_`j'.dta", clear 	
-		count 
-		local c = `r(N)' 
+		capture use "Block2_External/01_data/15industry_`j'.dta", clear 
+		if _rc == 0 {  // if file create, otherwise don't 
 		
-		#delimit ;
-		twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
-			   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
-			   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
-			   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
-			   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
-			   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
-			leg(off) ytitle("") xtitle("") name(Fig15_`j', replace)  
-		xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
-		ylabel( , nogrid angle(horizontal) labs(small))
-		scheme(s2mono) graphregion(fcolor(white) color(white))
-		subtitle("Employment in `: variable label value' (%)", position(11) justification(left) size(medsmall));
-		#delimit cr 
-		graph export "Block2_External/02_figures/Fig15_`j'.pdf", replace	
-	
+			count 
+			local c = `r(N)' 
+			
+			#delimit ;
+			twoway rcap    lb ub s1  if source == "GLD"                   , lcolor(red)                 ||
+				   scatter value s1  if source == "GLD"                   , msymbol(O) mcolor(red)      || 
+				   rcap    lb ub s1  if source != "GLD" & year == ${cyear}, lcolor(blue)                || 
+				   rcap    lb ub s1  if source != "GLD" & year != ${cyear}, lcolor(blue) lpattern(dash) || 
+				   scatter value s1  if source != "GLD" & year == ${cyear}, msymbol(O) mcolor(blue)     ||
+				   scatter value s1  if source != "GLD" & year != ${cyear}, msymbol(T) mcolor(blue)
+				leg(off) ytitle("") xtitle("") name(Fig15_`j', replace)  
+			xlabel(1(1)`c', valuelabel angle(45) labs(small)) 
+			ylabel( , nogrid angle(horizontal) labs(small))
+			scheme(s2mono) graphregion(fcolor(white) color(white))
+			subtitle("Employment in `: variable label value' (%)", position(11) justification(left) size(medsmall));
+			#delimit cr 
+			graph export "Block2_External/02_figures/Fig15_`j'.pdf", replace	
+			
+		}
+		
 	}
 	
 	
@@ -43,14 +47,30 @@
 *                           02. Combined figure                                *
 ********************************************************************************
 
-	#delimit;
-	gr combine Fig15_1 Fig15_2 Fig15_3 Fig15_4 Fig15_5 Fig15_6 Fig15_7 Fig15_8
-	           Fig15_9 Fig15_10,
-	scheme(s2mono) graphregion(fcolor(white) color(white)) c(3) 
-	subtitle("Block 2B.2. Sectors, detail, ${ccode3}", position(11) justification(left) size(medsmall));
-	#delimit cr
-	graph export "Block2_External/02_figures/2B2_figures.pdf", replace		
-	
+	* First sift which graphs where created, store that in local graphs_in_memory
+	local graphs_in_memory 
+	foreach fig in Fig15_1 Fig15_2 Fig15_3 Fig15_4 Fig15_5 Fig15_6 Fig15_7 Fig15_8 Fig15_9 Fig15_10 {
+		
+		capture gr describe `fig'
+		if _rc == 0 { // graph actully in memory
+			local graphs_in_memory `graphs_in_memory' `fig'
+		}
+		
+	}
+
+	* If not industry info, none of these figures will be drawn, proceed only if there are some
+	local graph_elements_n: word count `graphs_in_memory'
+	if `graph_elements_n' > 0 { // at least one figure
+	    
+		#delimit;
+		gr combine `graphs_in_memory',
+		scheme(s2mono) graphregion(fcolor(white) color(white)) c(3) 
+		subtitle("Block 2B.2. Sectors, detail, ${ccode3}", position(11) justification(left) size(medsmall));
+		#delimit cr
+		graph export "Block2_External/02_figures/2B2_figures.pdf", replace		
+		
+	}
+
 	
 	// cd "$mydir"
 	


### PR DESCRIPTION
Ensure figures are only created if previous code has created the files.

For example, code checks whether industrycat10 is there, only creates the collapse file if present.

However, the figures code just assumed files would be there, no checking (capture use "file"). Now this is done.