### PR TITLE
TUR 2004 v3 drop superfluous s

### DIFF
--- a/GLD/TUR/TUR_2004_HLFS/TUR_2004_HLFS_V01_M_V03_A_GLD/Programs/TUR_2004_HLFS_V01_M_V03_A_GLD_ALL.do
+++ b/GLD/TUR/TUR_2004_HLFS/TUR_2004_HLFS_V01_M_V03_A_GLD/Programs/TUR_2004_HLFS_V01_M_V03_A_GLD_ALL.do
@@ -747,7 +747,7 @@ foreach v of local ed_var {
 *</_unempldur_u_>
 }
 
-s
+
 *----------8.2: 7 day reference main job------------------------------*
 
 


### PR DESCRIPTION
An "s" to stop the process during debugging was still in the code.