### PR TITLE
Revisions to original variables and the drive name

### DIFF
--- a/GLD/IDN/IDN_1989_SAKERNAS/IDN_1989_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1989_Sakernas_v01_M_v04_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1989_SAKERNAS/IDN_1989_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1989_Sakernas_v01_M_v04_A_GLD_ALL.do
@@ -1,0 +1,1678 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1989_Sakernas_v01_M_v04_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-25 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					IDN_1989_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A   </_Sample size (HH)_>
+<_Sample size (IND)_> 		    283,278 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				N/A </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				N/A </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1989_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2023-01-12] File: [IDN_1989_Sakernas_v01_M_v03_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1989_Sakernas_v01_M_v04_A_GLD.do] - [Recode "industry_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1989"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v04"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas89.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	rename year Year
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// province = province
+// kab = district/city
+// rural = urban/rural
+// codesamp = sample code number
+// sampseq = household sample sequential number
+// hhseq = serial number of households
+
+But year 1989 was decided unable to recreate unique household IDs.
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	*sort province kab rural codesamp sampseq hhseq
+	*egen hhid = group(province kab rural codesamp sampseq hhseq)
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    283,276      100.00      100.00
+          1 |          4        0.00      100.00
+------------+-----------------------------------
+      Total |    283,280      100.00
+
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = infl
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	tostring quarter, gen(wave) format(%02.0f)
+	replace wave = "Q" + substr(wave, 2, 1)
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = rural
+	recode urban 0=1 1=0
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen subnatid1_copy = province
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 54 "54 - TIMUR TIMOR" 53 "53 - NUSA TENGGARA TIMUR" 54 "54 - TIMUR TIMOR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1989 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1996.
+
+	But note that 26 district codes only appear in 1989 (no district labels) not in 2013:
+1171
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7319 7320 7321 7371
+8184 8208 8209
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = kab
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = province
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	rename subnatid2_code b1r2
+	merge n:1 b1r2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = n_hhmem
+	label var hsize "Household size"
+*</_hsize_>
+
+
+/*<_age_>
+
+Note that because the variable of age is called "age" in the raw dataset,
+here I did not create a new variable.
+
+<_age_>*/
+
+
+*<_age_>
+	*gen age = Q14AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = .
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relationharm
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = .
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+/*<_school_>
+
+Note that variable "school" refers to be currently attending school; but the only
+variable viable for "school" is "inschool", which indicates the primary activity
+during the previous week.
+
+<_school_>*/
+
+
+*<_school_>
+	gen byte school = inschool
+	replace school = . if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "educa" in the dataset:
+
+1.Not/never been in school
+2.Not finished primary school yet
+3.Primary school
+4.Junior high school
+5.Vocational Jr. school
+6.Senior high school
+7.Vocational high school
+8.Diploma I/II
+9.Academy/Diploma III
+0.University
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring educa, replace
+	gen byte educat7 = educa
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = educa
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = educa
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (activity=="1")" or
+							  "worked at least for 1 hour in the past one week(work1hr=="1")" or
+							  "has a job/business but temporarily did not work during the past one week(absent=="1")";
+unemployed:"who do not have a job/business (absent=="2") & seeking a job (seeking==1)"
+non-labor force: "who do not have a job/business (absent=="2")" & not seeking a job (seeking==2).
+
+Labor force participation: 55.04%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if activity=="1" | work1hr=="1" | absent=="1"
+	replace lstatus = 2 if absent=="2" & seeking==1
+	replace lstatus = 3 if absent=="2" & seeking==2
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 2 if seeking==1 & lstatus==.
+	replace lstatus = 3 if seeking==2 & lstatus==.
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching or (wantwork==1 & subopt==0)
+2)searching but not immediately available to work (subopt==1 & wantwork==0)
+
+Note that the raw dataset seems to assume people who are looking for jobs are also
+willing to accept jobs and people who are not looking for jobs are not. But also
+note that 7,771 observations looking for jobs do not follow this rule. They may be
+errors and the reason for this is not known.
+
+In this case, no observations fit the requirement and will be assigned any non-missing values.
+
+   Want to |  LOOKING FOR OR WANT
+  accept a |         WORK
+       job |         0          1 |     Total
+-----------+----------------------+----------
+           |         0      7,771 |     7,771
+         1 |         0     52,465 |    52,465
+         2 |   223,038          0 |   223,038
+         9 |         6          0 |         6
+-----------+----------------------+----------
+     Total |   223,044     60,236 |   283,280
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if (wantwork=="1" & subopt==0) | (subopt==1 & wantwork=="2")
+	replace potential_lf = 0 if (wantwork=="1" & subopt==1) | (subopt==0 & wantwork=="0")
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason = .
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+Period of job seeking, or variable "b4p16" is not a range in the raw dataset.
+The unit is month but it is a specific value.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	destring seek_c, replace
+	gen byte unempldur_l = seek_c
+	replace unempldur_l = . if lstatus!=2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = seek_c
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	destring status, replace
+	gen byte empstat = status if inrange(status, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+The original code list of industry has 18 categories from 00 to 17. But the
+coding in the dataset is not correct. Some of the categories are named in the
+format of two digits, like 00 to 09 whereas the others are in one-digit format.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = industry
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industry2 = industry
+	destring industry2, replace
+	format industry2 %02.0f if inlist(substr(industry,1,1), "0")
+	gen byte industrycat10 = industry2
+	recode industrycat10 (01/04=1) (05=2) (06/09=3) (10=4) (11=5) (12=6) (13=7) (14=8) (15=9) (00 16 17=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = .
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = .
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	replace occup = . if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+Two variables in the raw dataset are the same --- "wagewk_c" and "wagewk"; the
+former is a string variable while the other one is a numeric variable.
+
+Note that these two variables reflect average weekly wage instead of the last payment.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = wagewk
+	replace wage_no_compen=. if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 2
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hrsmain
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+/*<_lstatus_year_note_>
+
+According to the original variable "b4r19", we only know whether a given respondent
+had a work or not in the last year. We do not know among those who did not have
+a work, who were actively seeking a job. Therefore, we cannot decide who are unemployed
+nor who are non-labor force.
+
+Same reason for leaving "potential_lf_year" missing.
+
+<_lstatus_year_note_>*/
+
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1990_SAKERNAS/IDN_1990_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1990_Sakernas_v01_M_v04_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1990_SAKERNAS/IDN_1990_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1990_Sakernas_v01_M_v04_A_GLD_ALL.do
@@ -1,0 +1,1655 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1990_Sakernas_v01_M_v04_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-25 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1990 </_Survey Year_>
+<_Study ID_>					IDN_1990_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Central Bureau of Statistics (BPS), Indonesia
+								Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			81,814   </_Sample size (HH)_>
+<_Sample size (IND)_> 		    291,095 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				N/A </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				N/A </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1990_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2023-01-12] File: [IDN_1990_Sakernas_v01_M_v03_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1990_Sakernas_v01_M_v04_A_GLD.do] - [Recode "industry_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1990"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v04"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas90.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1990
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "v01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "v02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1990
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// prop = province
+// kab = district/city
+// koped = urban/rural
+// nks = sample code number
+// nous = household sample sequential number
+// nour = serial number of households
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort prop kab koped nks nous nour
+	egen hhid = group(prop kab koped nks nous nour)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    291,095      100.00      100.00
+------------+-----------------------------------
+      Total |    291,095      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = inflate
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	tostring kuart, gen(wave) format(%02.0f)
+	replace wave = "Q" + substr(wave, 2, 1)
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = koped
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen subnatid1_copy = prop
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 54 "54 - TIMUR TIMOR" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1990 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1996.
+
+	But note that 26 district codes only appear in 1990 (no district labels) not in 2013:
+1171 1472
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7319 7320 7321 7371
+8208 8209
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = kab
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = prop
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	rename subnatid2_code b1r2
+	merge n:1 b1r2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = jart
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4p2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4p1
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = .
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relationharm
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = .
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+/*<_school_note_c>
+
+Note that variable "school" refers to be currently attending school; but the only
+variable viable for "school" is "b4p4", which indicates the primary activity
+during the previous week. Because we are not sure whether people have other primary
+activities are attending school or not, there is no category zero.
+
+<_school_note_>*/
+
+
+*<_school_>
+	gen byte school = .
+	replace school = 1 if b4p4 == 2
+	replace school = . if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "b4p3" in the dataset:
+
+1.Not/never been in school
+2.Not finished primary school yet
+3.Primary school
+4.Junior high school
+5.Vocational Jr. school
+6.Senior high school
+7.Vocational high school
+8.Diploma I/II
+9.Academy/Diploma III
+0.Diploma IV/Bachelor/Postgraduate
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p3
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p3
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p3
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p4==1)" or
+							  "worked at least for 1 hour last week (b4p5==1)" or
+							  "has a job/business but temporarily didn't work (b4p6==1)";
+unemployed: "who do not have a job/business (b4p6==2)" & seeking a job (b4p13==1);
+non-labor force: "who do not have a job/business (b4p6==2)" & not seeking a job (b4p13=!1).
+
+Labor force participation: 55.37%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p4==1 | b4p5==1 | b4p6==1
+	replace lstatus = 2 if b4p6==2 & b4p13==1
+	replace lstatus = 3 if b4p6==2 & b4p13==2
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching or (b4p13==1 & b4p14==2)
+2)searching but not immediately available to work (b4p14==1 & b4p13==2)
+
+Note that there are observations who want to accept a job (seen as being available)
+but not seeking for a job, which is different from year 1989. But no observation
+satisfies the second requirement.
+
+. tab b4p13 b4p14, m
+
+   Seeking |            Want to accept a job
+ for a job |       Yes         No          9          . |     Total
+-----------+--------------------------------------------+----------
+       Yes |         0          0          0      7,949 |     7,949
+        No |    55,680    227,464          2          0 |   283,146
+-----------+--------------------------------------------+----------
+     Total |    55,680    227,464          2      7,949 |   291,095
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b4p13==1 & b4p14==2 ] | [ b4p14==1 & b4p13==2]
+	replace potential_lf = 0 if [ b4p13==1 & b4p14==1 ] | [ b4p14==2 & b4p13==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason = .
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+Period of job seeking, or variable "b4p16" is not a range in the raw dataset.
+The unit is month but it is a specific value.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p16
+	replace unempldur_l = . if lstatus!=2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p16
+	replace unempldur_u=. if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+The original code list of industry has 18 categories from 00 to 17. But the
+coding in the dataset is not correct. Some of the categories are named in the
+format of two digits, like 00 to 09 whereas the others are in one-digit format.
+
+So for the variable "industry_orig", I corrected the very original codes and
+use the two-digit format.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p9
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b4p9
+	recode industrycat10 (1/4=1) (5=2) (6/9=3) (10=4) (11=5) (12=6) (13=7) (14=8) (15=9) (16 0 17=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = .
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = .
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	replace occup = . if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+The raw dataset has two wage-related variables --- b4p11mg, average weekly net salary
+and b4p11bl, average monthly net salary; both refer to the wage received from the main job.
+
+Note that these two variables reflect AVERAGE wage instead of LAST payment.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p11bl
+	replace wage_no_compen=. if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p12jj
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+/*<_lstatus_year_note_>
+
+According to the original variable "b4r19", we only know whether a given respondent
+had a work or not in the last year. We do not know among those who did not have
+a work, who were actively seeking a job. Therefore, we cannot decide who are unemployed
+nor who are non-labor force.
+
+Same reason for leaving "potential_lf_year" missing.
+
+<_lstatus_year_note_>*/
+
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1991_SAKERNAS/IDN_1991_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1991_Sakernas_v01_M_v04_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1991_SAKERNAS/IDN_1991_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1991_Sakernas_v01_M_v04_A_GLD_ALL.do
@@ -1,0 +1,1648 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1991_Sakernas_v01_M_v04_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-25 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					IDN_1991_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			81,595   </_Sample size (HH)_>
+<_Sample size (IND)_> 		    282,542 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				N/A </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				N/A </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1991_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2023-01-12] File: [IDN_1991_Sakernas_v01_M_v03_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1991_Sakernas_v01_M_v04_A_GLD.do] - [Recode "industry_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1991"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v04"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas91.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// prop = province
+// kab = district/city
+// koped = urban/rural
+// nks = sample code number
+// nous = household sample sequential number
+// nour = serial number of households
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort prop kab koped nks nous nour
+	egen hhid = group(prop kab koped nks nous nour)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    282,334      100.00      100.00
+------------+-----------------------------------
+      Total |    282,334      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = inflate
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	tostring kuart, gen(wave) format(%02.0f)
+	replace wave = "Q" + substr(wave, 2, 1)
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+/*<_urban_note_>
+
+Variable "koped" in the raw dataset is urban/rural variable but somehow this variable
+is wrongly coded --- it has 10 categories and does not have any value labels.
+Therefore, we do not know about the urban/rural status.
+
+<_urban_note_>*/
+
+
+*<_urban_>
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen subnatid1 = prop
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+Both province and district only have codes without name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = kab
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = prop
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2 = code_prop + code_kab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = jart
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4p2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4p1
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = .
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relationharm
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = .
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+/*<_school_>
+
+Note that variable "school" refers to be currently attending school; but the only
+variable viable for "school" is "b4p4", which indicates the primary activity
+during the previous week. Because we are not sure whether people have other primary
+activities are attending school or not, there is no category zero.
+
+<_school_>*/
+
+
+*<_school_>
+	gen byte school = .
+	replace school = 1 if b4p4 == 2
+	replace school = . if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "b4p3" in the dataset:
+
+1.Not/never been in school
+2.Not finished primary school yet
+3.Primary school
+4.Junior high school
+5.Vocational Jr. school
+6.Senior high school
+7.Vocational high school
+8.Diploma I/II
+9.Academy/Diploma III
+0.Diploma IV/Bachelor/Postgraduate
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p3
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p3
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p3
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p4==1)" or
+							  "worked at least for 1 hour last week (b4p5==1)" or
+							  "has a job/business but temporarily didn't work (b4p6==1)";
+unemployed: "who do not have a job/business (b4p6==2)" & seeking a job (b4p13==1);
+non-labor force: "who do not have a job/business (b4p6==2)" & not seeking a job (b4p13=!1).
+
+Labor force participation: 55.64%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p4==1 | b4p5==1 | b4p6==1
+	replace lstatus = 2 if b4p6==2 & b4p13==1
+	replace lstatus = 3 if b4p6==2 & b4p13==2
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 2 if b4p13==1 & lstatus==.
+	replace lstatus = 3 if b4p13==2 & lstatus==.
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching or (b4p13==1 & b4p14==2)
+2)searching but not immediately available to work (b4p14==1 & b4p13==2)
+
+Note that there are observations who want to accept a job (seen as being available)
+but not seeking for a job, which is different from year 1989. But no observation
+satisfies the second requirement.
+
+. tab b4p13 b4p14, m
+
+   Seeking |            Want to accept a job
+ for a job |       Yes         No          9          . |     Total
+-----------+--------------------------------------------+----------
+       Yes |         0          0          0      7,483 |     7,483
+        No |    53,837    221,013          1          0 |   274,851
+-----------+--------------------------------------------+----------
+     Total |    53,837    221,013          1      7,483 |   282,334
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b4p13==1 & b4p14==2 ] | [ b4p14==1 & b4p13==2]
+	replace potential_lf = 0 if [ b4p13==1 & b4p14==1 ] | [ b4p14==2 & b4p13==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason = .
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+Period of job seeking, or variable "b4p16" is not a range in the raw dataset.
+The unit is month but it is a specific value.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p16
+	replace unempldur_l = . if lstatus!=2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p16
+	replace unempldur_u=. if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+The original code list of industry has 18 categories from 00 to 17. But the
+coding in the dataset is not correct. Some of the categories are named in the
+format of two digits, like 00 to 09 whereas the others are in one-digit format.
+
+So for the variable "industry_orig", I corrected the very original codes and
+use the two-digit format.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p9
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b4p9
+	recode industrycat10 (01/04=1) (05=2) (06/09=3) (10=4) (11=5) (12=6) (13=7) (14=8) (15=9) (16 00 17=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = .
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = .
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	replace occup = . if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+The raw dataset has two wage-related variables --- b4p11mg, average weekly net salary
+and b4p11bl, average monthly net salary; both refer to the wage received from the main job.
+
+Note that these two variables reflect AVERAGE wage instead of LAST payment.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p11bl
+	replace wage_no_compen=. if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p12jj
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+/*<_lstatus_year_note_>
+
+According to the original variable "b4r19", we only know whether a given respondent
+had a work or not in the last year. We do not know among those who did not have
+a work, who were actively seeking a job. Therefore, we cannot decide who are unemployed
+nor who are non-labor force.
+
+Same reason for leaving "potential_lf_year" missing.
+
+<_lstatus_year_note_>*/
+
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1992_SAKERNAS/IDN_1992_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1992_Sakernas_v01_M_v04_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1992_SAKERNAS/IDN_1992_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1992_Sakernas_v01_M_v04_A_GLD_ALL.do
@@ -1,0 +1,1658 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1992_Sakernas_v01_M_v04_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-25 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1992 </_Survey Year_>
+<_Study ID_>					IDN_1992_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			72,756   </_Sample size (HH)_>
+<_Sample size (IND)_> 		    282,542 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				N/A </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				N/A </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1992_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2023-01-12] File: [IDN_1992_Sakernas_v01_M_v03_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1992_Sakernas_v01_M_v04_A_GLD.do] - [Recode "industry_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1992"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v04"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas92.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// prop = province
+// kab = district/city
+// koped = urban/rural
+// nks = sample code number
+// nour = household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort prop kab koped nks nour
+	egen hhid = group(prop kab koped nks nour)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    282,542      100.00      100.00
+------------+-----------------------------------
+      Total |    282,542      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = inflate
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	tostring kuart, gen(wave) format(%02.0f)
+	replace wave = "Q" + substr(wave, 2, 1)
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = koped
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen subnatid1_copy = prop
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 54 "54 - TIMUR TIMOR" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1992 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1996.
+
+	But note that 26 district codes only appear in 1992 (no district labels) not in 2013:
+1171 1472
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7319 7320 7321 7371
+8208 8209
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = kab
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = prop
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	rename subnatid2_code b1r2
+	merge n:1 b1r2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = jart
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4p2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4p1
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = .
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relationharm
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = .
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+/*<_school_note_>
+
+Note that variable "school" refers to be currently attending school; but the only
+variable viable for "school" is "b4p4", which indicates the primary activity
+during the previous week. Because we are not sure whether people have other primary
+activities are attending school or not, there is no category zero.
+
+<_school_note_>*/
+
+
+*<_school_>
+	gen byte school = .
+	replace school = 1 if b4p4 == 2
+	replace school=. if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "b4p3" in the dataset:
+
+1.Not/never been in school
+2.Not finished primary school yet
+3.Primary school
+4.Junior high school
+5.Vocational Jr. school
+6.Senior high school
+7.Vocational high school
+8.Diploma I/II
+9.Academy/Diploma III
+0.Diploma IV/Bachelor/Postgraduate
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p3
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p3
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p3
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p4==1)" or
+							  "worked at least for 1 hour last week (b4p5==1)" or
+							  "has a job/business but temporarily didn't work (b4p6==1)";
+unemployed: "who do not have a job/business (b4p6==2)" & seeking a job (b4p13==1);
+non-labor force: "who do not have a job/business (b4p6==2)" & not seeking a job (b4p13=!1).
+
+Labor force participation: 56.22%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p4==1 | b4p5==1 | b4p6==1
+	replace lstatus = 2 if b4p6==2 & b4p13==1
+	replace lstatus = 3 if b4p6==2 & b4p13==2
+	replace lstatus = 2 if b4p13==1 & lstatus==.
+	replace lstatus = 3 if b4p13==2 & lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching or (b4p13==1 & b4p14==2)
+2)searching but not immediately available to work (b4p14==1 & b4p13==2)
+
+Note that there are observations who want to accept a job (seen as being available)
+but not seeking for a job, which is different from year 1989. But no observation
+satisfies the second requirement.
+
+. tab b4p13 b4p14, m
+
+   Seeking |            Want to accept a job
+ for a job |       Yes         No          9          . |     Total
+-----------+--------------------------------------------+----------
+       Yes |         0          0          0      7,898 |     7,898
+        No |    54,277    220,364          3          0 |   274,644
+-----------+--------------------------------------------+----------
+     Total |    54,277    220,364          3      7,898 |   282,542
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b4p13==1 & b4p14==2 ] | [ b4p14==1 & b4p13==2]
+	replace potential_lf = 0 if [ b4p13==1 & b4p14==1 ] | [ b4p14==2 & b4p13==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason = .
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+Period of job seeking, or variable "b4p16" is not a range in the raw dataset.
+The unit is month but it is a specific value.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p16
+	replace unempldur_l = . if lstatus!=2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p16
+	replace unempldur_u=. if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+The original code list of industry has 18 categories from 00 to 17. But the
+coding in the dataset is not correct. Some of the categories are named in the
+format of two digits, like 00 to 09 whereas the others are in one-digit format.
+
+So for the variable "industry_orig", I corrected the very original codes and
+use the two-digit format.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p9
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b4p9
+	recode industrycat10 (01/04=1) (05=2) (06/09=3) (10=4) (11=5) (12=6) (13=7) (14=8) (15=9) (16 00 17=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = .
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = .
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	replace occup = . if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+The raw dataset has two wage-related variables --- b4p11mg, average weekly net salary
+and b4p11b1, average monthly net salary; both refer to the wage received from the main job.
+
+Note that these two variables reflect AVERAGE wage instead of LAST payment.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p11b1
+	replace wage_no_compen=. if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p8jj
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+/*<_lstatus_year_note_>
+
+According to the original variable "b4r19", we only know whether a given respondent
+had a work or not in the last year. We do not know among those who did not have
+a work, who were actively seeking a job. Therefore, we cannot decide who are unemployed
+nor who are non-labor force.
+
+Same reason for leaving "potential_lf_year" missing.
+
+<_lstatus_year_note_>*/
+
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1993_SAKERNAS/IDN_1993_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1993_Sakernas_v01_M_v04_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1993_SAKERNAS/IDN_1993_Sakernas_v01_M_v04_A_GLD/Programs/IDN_1993_Sakernas_v01_M_v04_A_GLD_ALL.do
@@ -1,0 +1,1649 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1993_Sakernas_v01_M_v04_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-25 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					IDN_1993_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			81,618    </_Sample size (HH)_>
+<_Sample size (IND)_> 		    279,784 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				N/A </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				N/A </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1993_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2023-01-12] File: [IDN_1993_Sakernas_v01_M_v03_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1993_Sakernas_v01_M_v04_A_GLD.do] - [Recode "industry_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1993"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v04"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas93.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// prop = province
+// kab = district/city
+// koped = urban/rural
+// nks = sample code number
+// nous = household sample sequential number
+// nour = serial number of households
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort prop kab koped nks nous nour
+	egen hhid = group(prop kab koped nks nous nour)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    279,784      100.00      100.00
+------------+-----------------------------------
+      Total |    279,784      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = inflate
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	tostring kuart, gen(wave) format(%02.0f)
+	replace wave = "Q" + substr(wave, 2, 1)
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+/*<_urban_note_>
+
+Variable "koped" in the raw dataset is urban/rural variable but somehow this variable
+is wrongly coded --- it has 10 categories and does not have any value labels.
+Therefore, we do not know about the urban/rural status.
+
+<_urban_note_>*/
+
+
+*<_urban_>
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen subnatid1 = prop
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+Both province and district only have codes without name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = kab
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = prop
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2 = code_prop + code_kab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = jart
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4p2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4p1
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = .
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relationharm
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = .
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+/*<_school_note_>
+
+Note that variable "school" refers to be currently attending school; but the only
+variable viable for "school" is "b4p4", which indicates the primary activity
+during the previous week. Because we are not sure whether people have other primary
+activities are attending school or not, there is no category zero.
+
+<_school_note_>*/
+
+
+*<_school_>
+	gen byte school = .
+	replace school = 1 if b4p4 == 2
+	replace school = . if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "b4p3" in the dataset:
+
+1.Not/never been in school
+2.Not finished primary school yet
+3.Primary school
+4.Junior high school
+5.Vocational Jr. school
+6.Senior high school
+7.Vocational high school
+8.Diploma I/II
+9.Academy/Diploma III
+0.Diploma IV/Bachelor/Postgraduate
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p3
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p3
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p3
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p4==1)" or
+							  "worked at least for 1 hour last week (b4p5==1)" or
+							  "has a job/business but temporarily didn't work (b4p6==1)";
+unemployed: "who do not have a job/business (b4p6==2)" & seeking a job (b4p13==1);
+non-labor force: "who do not have a job/business (b4p6==2)" & not seeking a job (b4p13=!1).
+
+Labor force participation: 55.80%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p4==1 | b4p5==1 | b4p6==1
+	replace lstatus = 2 if b4p6==2 & b4p13==1
+	replace lstatus = 3 if b4p6==2 & b4p13==2
+	replace lstatus = 2 if b4p13==1 & lstatus==.
+	replace lstatus = 3 if b4p13==2 & lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching or (b4p13==1 & b4p14==2)
+2)searching but not immediately available to work (b4p14==1 & b4p13==2)
+
+Note that there are observations who want to accept a job (seen as being available)
+but not seeking for a job, which is different from year 1989. But no observation
+satisfies the second requirement.
+
+. tab b4p13 b4p14, m
+
+   Seeking |       Want to accept a job
+ for a job |       Yes         No          . |     Total
+-----------+---------------------------------+----------
+       Yes |         0          0      7,601 |     7,601
+        No |    55,328    216,855          0 |   272,183
+-----------+---------------------------------+----------
+     Total |    55,328    216,855      7,601 |   279,784
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b4p13==1 & b4p14==2 ] | [ b4p14==1 & b4p13==2]
+	replace potential_lf = 0 if [ b4p13==1 & b4p14==1 ] | [ b4p14==2 & b4p13==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason = .
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+Period of job seeking, or variable "b4p16" is not a range in the raw dataset.
+The unit is month but it is a specific value.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p16
+	replace unempldur_l = . if lstatus!=2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p16
+	replace unempldur_u=. if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+The original code list of industry has 18 categories from 00 to 17. But the
+coding in the dataset is not correct. Some of the categories are named in the
+format of two digits, like 00 to 09 whereas the others are in one-digit format.
+
+So for the variable "industry_orig", I corrected the very original codes and
+use the two-digit format.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p9
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b4p9
+	recode industrycat10 (01/04=1) (05=2) (06/09=3) (10=4) (11=5) (12=6) (13=7) (14=8) (15=9) (16 00 17=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = .
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = .
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	replace occup = . if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+The raw dataset has two wage-related variables --- b4p11mg, average weekly net salary
+and b4p11bl, average monthly net salary; both refer to the wage received from the main job.
+
+Note that these two variables reflect AVERAGE wage instead of LAST payment.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p11bl
+	replace wage_no_compen=. if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p12jj
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+/*<_lstatus_year_>
+
+According to the original variable "b4r19", we only know whether a given respondent
+had a work or not in the last year. We do not know among those who did not have
+a work, who were actively seeking a job. Therefore, we cannot decide who are unemployed
+nor who are non-labor force.
+
+Same reason for leaving "potential_lf_year" missing.
+
+<_lstatus_year_>*/
+
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1994_SAKERNAS/IDN_1994_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1994_Sakernas_v01_M_v06_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1994_SAKERNAS/IDN_1994_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1994_Sakernas_v01_M_v06_A_GLD_ALL.do
@@ -1,0 +1,1694 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1994_Sakernas_v01_M_v06_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-25 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					IDN_1994_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			72,457 </_Sample size (HH)_>
+<_Sample size (IND)_> 			245,207 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 1990 </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1994_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-24] File: [IDN_1994_Sakernas_v01_M_v03_A_GLD.do] - [Recode "occup_skill" and "occup"; change path to the intermediate file]
+* Date: [2022-11-07] File: [IDN_1994_Sakernas_v01_M_v04_A_GLD.do] - [Added occup based on KBJI1982 two digits and KBJI2002 one digit]
+* Date: [2023-01-12] File: [IDN_1994_Sakernas_v01_M_v05_A_GLD.do] - [Change directories; revised lstatus: seeking work question used was changed from b4p15 to b4p14; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1994_Sakernas_v01_M_v06_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1994"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v06"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas94.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// prop = province
+// kab = district/city
+// daerah = urban/rural
+// nokode = sample code number
+// nosamp = household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort prop kab daerah nokode nosamp
+	egen hhid = group(prop kab daerah nokode nosamp)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    245,207      100.00      100.00
+------------+-----------------------------------
+      Total |    245,207      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = daerah
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen subnatid1_copy = prop
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 54 "54 - TIMUR TIMOR" 53 "53 - NUSA TENGGARA TIMUR" 54 "54 - TIMUR TIMOR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1994 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1994.
+
+	But note that 27 district codes only appear in 1994 (no district labels) not in 2013:
+.25
+1171 1472
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7319 7320 7321 7371
+8208 8209
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = kab
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = prop
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	rename subnatid2_code b1r2
+	merge n:1 b1r2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	drop _merge
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = jart
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4p2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4p1
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = .
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relationharm
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = .
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+/*<_school_note_>
+
+Note that variable "school" refers to be currently attending school; but the only
+variable viable for "school" is "b4p4", which indicates the primary activity
+during the previous week. Because we are not sure whether people have other primary
+activities are attending school or not, there is no category zero.
+
+<_school_note_>*/
+
+
+*<_school_>
+	gen byte school = .
+	replace school = 1 if b4p4 == 2
+	replace school=. if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "b4p3" in the dataset:
+
+1.Not/never been in school
+2.Not finished primary school yet
+3.Primary school
+4.Junior high school
+5.Vocational Jr. school
+6.Senior high school
+7.Vocational high school
+8.Diploma I/II
+9.Academy/Diploma III
+0.Diploma IV/Bachelor/Postgraduate
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p3
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p3
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p3
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p4==1)" or
+							  "worked at least for 1 hour last week (b4p5==1)" or
+							  "has a job/business but temporarily didn't work (b4p6==1)";
+unemployed: "who do not have a job/business (b4p6==2)" & seeking a job (b4p14==1);
+non-labor force: "who do not have a job/business (b4p6==2)" & not seeking a job (b4p14=!1).
+
+Labor force participation: 60.17%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p4==1 | b4p5==1 | b4p6==1
+	replace lstatus = 2 if b4p6==2 & b4p14==1
+	replace lstatus = 3 if b4p6==2 & b4p14==2
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching or (b4p15==1 & b4p14==2)
+2)searching but not immediately available to work (b4p14==1 & b4p15==2)
+
+Note that there are observations who want to accept a job (seen as being available)
+but not seeking for a job, which is different from year 1989. But no observation
+satisfies the second requirement.
+
+In this case, 55,680 observations fit the requirement and will be assigned any non-missing values.
+
+. tab b4p15 b4p14, m
+
+   Want to |
+  accept a |        Seeking for a job
+       job |       Yes         No          . |     Total
+-----------+---------------------------------+----------
+       Yes |         0     50,096          0 |    50,096
+        No |         0    184,159          0 |   184,159
+         . |    10,950          0          2 |    10,952
+-----------+---------------------------------+----------
+     Total |    10,950    234,255          2 |   245,207
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b4p15==1 & b4p14==2 ] | [ b4p14==1 & b4p15==2]
+	replace potential_lf = 0 if [ b4p15==1 & b4p14==1 ] | [ b4p14==2 & b4p15==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason = .
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+Period of job seeking, or variable "b4p17" is not a range in the raw dataset.
+The unit is month but it is a specific value.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p17
+	replace unempldur_l = . if lstatus!=2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p17
+	replace unempldur_u=. if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p11 if inrange(b4p11, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+The original code list of industry has 18 categories from 00 to 17. But the
+coding in the dataset is not correct. Some of the categories are named in the
+format of two digits, like 00 to 09 whereas the others are in one-digit format.
+
+So for the variable "industry_orig", I corrected the very original codes and
+use the two-digit format.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p9
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b4p9
+	recode industrycat10 (01/04=1) (05=2) (06/09=3) (10=4) (11=5) (12=6) (13=7) (14=8) (15=9) (16 00 17=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p10
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p10
+	recode occup_isco (55=5)
+	replace occup_isco = occup_isco*100
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if occup_isco=="."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p10
+	merge m:1 kji1982 urban using "`path_in_stata'\kji_2d_corresp.dta", keep(match master) nogen
+	* set seed so process is reproducible
+	set seed 123
+	gen helper_occup = uniform()
+
+
+	* First define cases for shorthand
+	gen cases = .
+	replace cases = 1 if missing(option_2)
+	replace cases = 2 if !missing(cp_2) & missing(cp_3)
+	replace cases = 3 if !missing(cp_3) & missing(cp_4)
+	replace cases = 4 if !missing(cp_4) & missing(cp_5)
+	replace cases = 5 if !missing(cp_5)
+
+* Assign occup options
+	gen occup = .
+	replace occup = option_1 if cases == 1
+	replace occup = option_1 if inrange(helper_occup,0,cp_1) & inrange(cases,2,5)
+	replace occup = option_2 if inrange(helper_occup,cp_1, cp_2) & inrange(cases,2,5)
+	replace occup = option_3 if inrange(helper_occup,cp_2, cp_3) & inrange(cases,3,5)
+	replace occup = option_3 if inrange(helper_occup,cp_3, cp_4) & inrange(cases,4,5)
+	replace occup = option_3 if inrange(helper_occup,cp_4, cp_5) & cases == 5
+	replace occup=. if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations" 10 "Armed forces" 99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+The raw dataset has two wage-related variables --- b4p12mg, average weekly net salary
+and b4p12bl, average monthly net salary; both refer to the wage received from the main job.
+
+Note that these two variables reflect AVERAGE wage instead of LAST payment.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12bl
+	replace wage_no_compen=. if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p13jj
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+/*<_lstatus_year_note_>
+
+According to the original variable "b4r19", we only know whether a given respondent
+had a work or not in the last year. We do not know among those who did not have
+a work, who were actively seeking a job. Therefore, we cannot decide who are unemployed
+nor who are non-labor force.
+
+Same reason for leaving "potential_lf_year" missing.
+
+<_lstatus_year_note_>*/
+
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1996_SAKERNAS/IDN_1996_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1996_Sakernas_v01_M_v06_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1996_SAKERNAS/IDN_1996_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1996_Sakernas_v01_M_v06_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1996_Sakernas_v01_M_v06_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-07-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					IDN_1996_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			73,629  </_Sample size (HH)_>
+<_Sample size (IND)_> 			247,190 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 1990 </_INDUS National_>
+-----------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1996_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-24] File: [IDN_1996_Sakernas_v01_M_v03_A_GLD.do] - [Recode "occup_skill" and "occup"; change path to the intermediate file]
+* Date: [2022-11-07] File: [IDN_1996_Sakernas_v01_M_v04_A_GLD.do] - [Added occup based on KBJI1982 two digits and KBJI2002 one digit]
+* Date: [2023-01-12] File: [IDN_1996_Sakernas_v01_M_v05_A_GLD.do] - [Change directories; revised lstatus: seeking work question used was changed from b4p15 to b4p14; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1996_Sakernas_v01_M_v06_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1996"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v06"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas96.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Note that 136,655 observations' or 40,356 households' number of household member do
+not match the original household size variable "b1r12".
+
+	bys hhid: egen hhsize=count(pid)
+	gen gap=hhsize-b1r12
+	codebook hhid if gap!=0
+	codebook pid if gap!=0
+	gen unmatch=cond(gap!=0, 1, 0)
+	tab unmatch
+
+	gen hhsize_larger=cond(gap>0, 1, 0)
+	replace hhsize_larger=. if gap==0
+	tab hhsize_larger, m
+
+    unmatch |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    110,544       44.72       44.72
+          1 |    136,655       55.28      100.00
+------------+-----------------------------------
+      Total |    247,199      100.00
+
+hhsize_larg |
+         er |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    135,464       54.80       54.80
+          1 |      1,191        0.48       55.28
+          . |    110,544       44.72      100.00
+------------+-----------------------------------
+      Total |    247,199      100.00
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1r1 = province
+// b1r2 = district/city
+// b1r3 = sub-district
+// b1r4 = village/kelurahan
+// b1r5 = village/kelurahan classification
+(urban/rural)
+// b1r7 = sample code number
+// b1r10 = household sample sequential number
+
+<_hhid__note_>*/
+
+
+*<_hhid_>
+	duplicates drop
+	sort b1r1-b1r10
+	egen hhid = group(b1r1-b1r10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    247,181       99.99       99.99
+          1 |         18        0.01      100.00
+------------+-----------------------------------
+      Total |    247,199      100.00
+
+9 observations were dropped.
+
+<_pid__note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = wgt96
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = b1r5
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+/*<_subnatid1_note_>
+
+The original province variable "b1r1" does not have value label for category 54.
+The name of category 54 is from year 1995. The province codelist is the same for
+year 1995 and 1996 and East Timor is the only province missing among the 27
+provinces.
+
+Province 54 - Timur Timor became independent from Indonesia in 2002.
+
+<_subnatid1_note_>*/
+
+
+*<_subnatid1_>
+	gen subnatid1_copy = b1r1
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 54 "54 - TIMUR TIMOR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1996 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1996.
+
+	But note that 27 district codes only appear in 1996 (no district labels) not in 2013:
+1171 1472
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7271 7319 7320 7321 7371
+8208 8209
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1r2
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = b1r1
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1r2
+	rename subnatid2_code b1r2
+	merge n:1 b1r2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	drop _merge
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b1r12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b3k5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b3k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b3k3
+	recode relationharm (4 7=5) (5=3) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b3k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b3k6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+/* <_ed_mod_age_note>
+
+Education module is only asked to those 10 and older.
+
+</_ed_mod_age_note> */
+
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b3k7
+	recode school (1 3=0) (2=1)
+	replace school = . if age<ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+Original code list of variable "b4r2" in the dataset:
+
+1.No/never in school
+2.No/not yet finish Primary School
+3.Primary School
+4.Public Junior High School
+5.Vocational Junior High School
+6.Public Senior High School
+7.Vocational Senior High School
+8.Diploma I/II
+9.Academy/Diploma III
+0.Diploma IV/Bachelor/Postgraduate
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing and so were educat7, educat5,
+and educat4.
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age<ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4r2
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age<ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4r2
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4r2
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v'=. if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v="." if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4r3==1)" or
+							  "worked at least for 1 hour last week (b4r4==1)" or
+							  "has a job/business but temporarily didn't work (b4r5==1)";
+unemployed: "who do not have a job/business (b4r5==2)" & seeking a job (b4r14==1);
+non-labor force: "who do not have a job/business (b4r5==2)" & not seeking a job (b4r14=!1).
+
+Labor force participation: 56.21%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4r3==1 | b4r4==1 | b4r5==1
+	replace lstatus = 2 if b4r4==2 & b4r14==1
+	replace lstatus = 3 if b4r4==2 & b4r14==2
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4r16==1 & b4r14==2) or
+2)searching but not immediately available to work (b4r14==1 & b4r16==2)
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b4r16==1 & b4r14==2 ] | [b4r14==1 & b4r16==2]
+	replace potential_lf = 0 if [ b4r14==1 & b4r16==1 ] | [b4r14==2 & b4r16==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4r15 " has 5 non-missing categories:
+	1  Did not need work
+	2  Futile
+	3  Attending school
+	4  Housekeeping
+	5  Others
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4r15
+	recode nlfreason (3=1) (4=2) (1/2=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4r18" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4r18
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4r18
+	replace unempldur_u = . if lstatus != 2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4r10 if inrange(b4r10, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat = . if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Variable "b4r8" has the KJI 1982 codes which is the national occupational
+classifications.
+
+Variable "b4r9" has 48 unique values and seems to also follow the KJI 1982
+industrial classifications.
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b4r9
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic =  "" 
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10 = floor(b4r9/10)
+	replace industrycat10=10 if inrange(b4r9,92,99)
+	replace industrycat10=10 if industrycat10==0 
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4r8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4r8
+	recode occup_isco (55=5)
+	replace occup_isco = occup_isco*100
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if occup_isco=="."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4r8
+	merge m:1 kji1982 urban using "`path_in_stata'\kji_2d_corresp.dta", keep(match master) nogen
+	* set seed so process is reproducible
+	set seed 123
+	gen helper_occup = uniform()
+
+
+	* First define cases for shorthand
+	gen cases = .
+	replace cases = 1 if missing(option_2)
+	replace cases = 2 if !missing(cp_2) & missing(cp_3)
+	replace cases = 3 if !missing(cp_3) & missing(cp_4)
+	replace cases = 4 if !missing(cp_4) & missing(cp_5)
+	replace cases = 5 if !missing(cp_5)
+
+* Assign occup options
+	gen occup = .
+	replace occup = option_1 if cases == 1
+	replace occup = option_1 if inrange(helper_occup,0,cp_1) & inrange(cases,2,5)
+	replace occup = option_2 if inrange(helper_occup,cp_1, cp_2) & inrange(cases,2,5)
+	replace occup = option_3 if inrange(helper_occup,cp_2, cp_3) & inrange(cases,3,5)
+	replace occup = option_3 if inrange(helper_occup,cp_3, cp_4) & inrange(cases,4,5)
+	replace occup = option_3 if inrange(helper_occup,cp_4, cp_5) & cases == 5
+	replace occup=. if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations" 10 "Armed forces" 99 "Others"
+	label values occup lbloccup
+
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4r11a + b4r11b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4r7
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4r12==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+/*<_industry_orig_2_note_>
+
+There are two original variables concerning industrial classification:
+
+b4r13 --- Type of industry/line of business of the main additional job
+b4r20 --- Type of industry/activities of job during the previous year
+
+Variable "b4r13" is not 7-day reference and it does not have value labels.
+It follows KJI 1982 industrial classifications.
+
+<_industry_orig_2_note_>*/
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4r13
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%04.0f)
+	replace industrycat_isic_2= "" if b4r12!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year = . if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year =.
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = b4r20
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1997_SAKERNAS/IDN_1997_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1997_Sakernas_v01_M_v06_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1997_SAKERNAS/IDN_1997_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1997_Sakernas_v01_M_v06_A_GLD_ALL.do
@@ -1,0 +1,1724 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1997_Sakernas_v01_M_v06_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					IDN_1997_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			65,648  </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,439 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 1997 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1997_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-24] File: [IDN_1997_Sakernas_v01_M_v03_A_GLD.do] - [Recode "occup_skill" and "occup"; change path to the intermediate file]
+* Date: [2022-11-07] File: [IDN_1997_Sakernas_v01_M_v04_A_GLD.do] - [Recode "occup_skill" and "occup"; change path to the intermediate file] 
+* Date: [2023-01-12] File: [IDN_1997_Sakernas_v01_M_v05_A_GLD.do] - [Change directories; fix "primary school completed" of educat7; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1997_Sakernas_v01_M_v06_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1997"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v06"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas97.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p1-b1p10
+	egen hhid = group(b1p1-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    219,439      100.00      100.00
+------------+-----------------------------------
+      Total |    219,439      100.00
+
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = timbang
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen urban = b1p5
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+/*<_subnatid1_note_>
+
+Province 54 - Timur Timor became independent from Indonesia in 2002.
+
+<_subnatid1_note_>*/
+
+
+*<_subnatid1_>
+	gen subnatid1_copy = b1p1
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 54 "54 - TIMUR TIMOR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1997 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1997.
+
+	But note that 27 district codes only appear in 1997 (no district labels) not in 2013:
+1171 1472
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7271 7319 7320 7321 7371
+8208 8209
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p2
+	tostring code_kab, format (%02.0f) replace
+	gen code_prop = b1p1
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p2
+	rename subnatid2_code b1p2
+	merge n:1 b1p2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b3p5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b3p4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b3p3
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b3p3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b3p6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital4 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b3p7
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1" in the dataset:
+
+00          No/Not in school yet
+11/12/13    Did not complete/have not completed primary school
+21/22/23    Primary school
+31/32/33    Public school junior high
+41/42/43    Vocational junior school
+51/52/53    Senior high school
+61/62/63    Vocational senior high school
+71/72/73    Diploma I/II
+81/82/83    Diploma III
+91/92/93    Univ./Diploma IV
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy=. if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	tostring b4p1, gen(educat7_sub)
+	gen educat7_sub1 = substr(educat7_sub, 1, 1)
+	destring educat7_sub1, gen (educat7)
+	recode educat7 (0=1) (1=2) (2=3) (3/4=4) (5/6=5) (7/8=6) (9=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1
+	recode educat_isced (0=020) (1/2=100) (3/4=244) (5/6=344) (7=454) (8=550) (9=660)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p4b==1)" or
+							  "worked at least 1 hour during the last week (b4p5==1)" or
+							  "has a job but was temporarily out of work (b4p8==1)";
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p15==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p15==2)"
+
+labour force participation: 56.78%
+
+. count if !mi(b4p8)
+  121,541
+
+<_lstatus_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p4b==1 | b4p5==1 | b4p8==1
+	replace lstatus = 2 if lstatus != 1 & (b4p15==1)
+	replace lstatus = 3 if lstatus != 1 & (b4p15==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p21==1 & (b4p15==2)) or
+2)searching but not immediately available to work (b4p15==1) & b4p21==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p21==1 & (b4p15==2)] | [ b4p15==1 & b4p21==2 ]
+	replace potential_lf = 0 if [b4p21==1 & b4p15==1] | [ b4p15==2 & b4p21==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p20" has 6 non-missing categories:
+	1 Satisfied with current job/no need
+	2 Futile
+	3 Attending schooling
+	4 Housekeeping
+	5 Not able to work
+	6 Other
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p20
+	recode nlfreason (3=1) (4=2) (5=4) (1 2 6=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p18" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p18
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p18
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = . 
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p6
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+/*<_industrycat_isic_note_>
+
+The original industrial classification used in 1997, "b4p6", is supposed to be KBLI 1997 which is based on ISIC Rev.3 .
+
+However, in the raw dataset, "b4p6" only has two categories without labels. Since we do not know what these categories represent and they do not match the structure of KBLI1997, following industry mappings were not coded.
+
+<_industrycat_isic_note_>*/
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = .
+	replace industrycat_isic = . if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = .
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p9
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p9
+	recode occup_isco (55=5) (65/67=.)
+	replace occup_isco = occup_isco*100
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if occup_isco=="."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p9
+	merge m:1 kji1982 urban using "`path_in_stata'\kji_2d_corresp.dta", keep(match master) nogen
+	* set seed so process is reproducible
+	set seed 123
+	gen helper_occup = uniform()
+	* First define cases for shorthand
+	gen cases = .
+	replace cases = 1 if missing(option_2)
+	replace cases = 2 if !missing(cp_2) & missing(cp_3)
+	replace cases = 3 if !missing(cp_3) & missing(cp_4)
+	replace cases = 4 if !missing(cp_4) & missing(cp_5)
+	replace cases = 5 if !missing(cp_5)
+* Assign occup options
+	gen occup = .
+	replace occup = option_1 if cases == 1
+	replace occup = option_1 if inrange(helper_occup,0,cp_1) & inrange(cases,2,5)
+	replace occup = option_2 if inrange(helper_occup,cp_1, cp_2) & inrange(cases,2,5)
+	replace occup = option_3 if inrange(helper_occup,cp_2, cp_3) & inrange(cases,3,5)
+	replace occup = option_3 if inrange(helper_occup,cp_3, cp_4) & inrange(cases,4,5)
+	replace occup = option_3 if inrange(helper_occup,cp_4, cp_5) & cases == 5
+	replace occup=. if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations" 10 "Armed forces" 99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12a1 + b4p12a2
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p7b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p13==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p14
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%04.0f)
+	replace industrycat_isic_2= "" if b4p13!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1998_SAKERNAS/IDN_1998_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1998_Sakernas_v01_M_v06_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1998_SAKERNAS/IDN_1998_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1998_Sakernas_v01_M_v06_A_GLD_ALL.do
@@ -1,0 +1,1735 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1998_Sakernas_v01_M_v06_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					IDN_1998_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			49,150  </_Sample size (HH)_>
+<_Sample size (IND)_> 			163,515 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 1990 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1998_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-24] File: [IDN_1998_Sakernas_v01_M_v03_A_GLD.do] - [Recode "occup_skill" and "occup"; change path to the intermediate file]
+* Date: [2022-11-07] File: [IDN_1998_Sakernas_v01_M_v04_A_GLD.do] - [Added occup based on KBJI1982 two digits and KBJI2002 one digit]
+* Date: [2023-01-12] File: [IDN_1998_Sakernas_v01_M_v05_A_GLD.do] - [Change directories; industrycat10 updated; ISIC version changed from ISIC Rev.3 to missing; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1998_Sakernas_v01_M_v06_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1998"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v06"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas98.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p1-b1p10
+	egen hhid = group(b1p1-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    163,513      100.00      100.00
+          1 |          4        0.00      100.00
+------------+-----------------------------------
+      Total |    163,517      100.00
+
+	  2 observations were dropped.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	destring weight, replace
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	destring b1p5, gen(urban)
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+/*<_subnatid1_note_>
+
+Province 54 - Timur Timor became independent from Indonesia in 2002.
+
+<_subnatid1_note_>*/
+
+
+*<_subnatid1_>
+	destring b1p1, gen(subnatid1_copy)
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR"  51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 54 "54 - TIMUR TIMOR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1998 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1998.
+
+	But note that 30 district codes only appear in 1998 (no district labels) not in 2013:
+1171 1472
+3218 3219 3220 3273
+5401 5402 5403 5404 5405 5406 5407 5408 5409 5410 5411 5412 5413
+6271
+7271 7319 7320 7321 7371
+8208 8209 8210 8211 8212
+These districts' names were left missing.
+
+Province 54 - East Timor became indipendent from Indonesia in 2002. All districts in province 54 do not have names as in no year do these districts have name labels.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	destring b1p2, replace
+	gen code_kab = b1p2
+	tostring code_kab, format (%02.0f) replace
+	destring b1p1, gen (code_prop)
+	tostring code_prop, format (%02.0f) replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p2
+	rename subnatid2_code b1p2
+	merge n:1 b1p2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	destring b1p12, replace
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	destring b3p5, replace
+	gen age = b3p5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring b3p4, replace
+	gen male = b3p4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring b3p3, replace
+	gen byte relationharm = b3p3
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b3p3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring b3p6, replace
+	gen byte marital = b3p6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring b3p7, replace
+	gen byte school = b3p7
+	recode school (1 3=0) (2=1)
+	replace school=. if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+0.University/D. IV
+1.Did not attend/have not attended school
+2.Did not complete/have not completed primary school
+3.Primary school
+4.Public junior high school/TSANAWIYAH
+5.Vocational junior high school
+6.Public senior high school/ALIYAH
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy=. if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring b4p1a, replace
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2b ==1)" or
+							  "worked at least 1 hour during the last week (b4p3==1)" or
+							  "has a job but was temporarily out of work (b4p4==1)";
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p13==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p13==2)"
+
+labour force participation: 58.98%
+
+. count if !mi(b4p6)
+  91,242
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	destring b4p2b b4p3 b4p4 b4p13, replace
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2b==1 | b4p3==1 | b4p4==1
+	replace lstatus = 2 if lstatus != 1 & (b4p13==1)
+	replace lstatus = 3 if lstatus != 1 & (b4p13==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p19==1 & (b4p13==2)) or
+2)searching but not immediately available to work (b4p13==1) & b4p19==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	destring b4p19, replace
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p19==1 & (b4p13==2)] | [ b4p13==1 & b4p19==2 ]
+	replace potential_lf = 0 if [b4p19==1 & b4p13==1] | [ b4p13==2 & b4p19==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p18" has 6 non-missing categories:
+	1 Satisfied with current job/no need
+	2 Futile
+	3 Attending schooling
+	4 Housekeeping
+	5 Not able to work
+	6 Other
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	destring b4p18, replace
+	gen byte nlfreason = b4p18
+	recode nlfreason (3=1) (4=2) (5=4) (1 2 6=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p16" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	destring b4p16, replace
+	gen byte unempldur_l = b4p16
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p16
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	destring b4p9, replace
+	gen byte empstat = b4p9 if inrange(b4p9, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p6
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	destring b4p6, replace 
+	gen industrycat10 = floor(b4p6/10)
+	replace industrycat10=10 if inrange(b4p6,92,99)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p7
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	destring b4p7, replace
+	gen occup_isco = b4p7
+	recode occup_isco (55=5)
+	replace occup_isco = occup_isco*100
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if occup_isco=="."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p7
+	merge m:1 kji1982 urban using "`path_in_stata'\kji_2d_corresp.dta", keep(match master) nogen
+	* set seed so process is reproducible
+	set seed 123
+	gen helper_occup = uniform()
+	* First define cases for shorthand
+	gen cases = .
+	replace cases = 1 if missing(option_2)
+	replace cases = 2 if !missing(cp_2) & missing(cp_3)
+	replace cases = 3 if !missing(cp_3) & missing(cp_4)
+	replace cases = 4 if !missing(cp_4) & missing(cp_5)
+	replace cases = 5 if !missing(cp_5)
+* Assign occup options
+	gen occup = .
+	replace occup = option_1 if cases == 1
+	replace occup = option_1 if inrange(helper_occup,0,cp_1) & inrange(cases,2,5)
+	replace occup = option_2 if inrange(helper_occup,cp_1, cp_2) & inrange(cases,2,5)
+	replace occup = option_3 if inrange(helper_occup,cp_2, cp_3) & inrange(cases,3,5)
+	replace occup = option_3 if inrange(helper_occup,cp_3, cp_4) & inrange(cases,4,5)
+	replace occup = option_3 if inrange(helper_occup,cp_4, cp_5) & cases == 5
+	replace occup=. if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations" 10 "Armed forces" 99 "Others"
+	label values occup lbloccup
+
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+	
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	destring b4p10a b4p10b, replace
+	gen double wage_no_compen = b4p10a + b4p10b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	destring b4p5b, replace
+	gen whours = b4p5b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	destring b4p11, replace
+	gen byte empstat_2 = 5 if b4p11==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p12
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%04.0f)
+	replace industrycat_isic_2= "" if b4p11!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_1999_SAKERNAS/IDN_1999_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1999_Sakernas_v01_M_v06_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_1999_SAKERNAS/IDN_1999_Sakernas_v01_M_v06_A_GLD/Programs/IDN_1999_Sakernas_v01_M_v06_A_GLD_ALL.do
@@ -1,0 +1,1698 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_1999_Sakernas_v01_M_v06_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					IDN_1999_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			47,580  </_Sample size (HH)_>
+<_Sample size (IND)_> 			155,572 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 1990 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_1999_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-24] File: [IDN_1999_Sakernas_v01_M_v03_A_GLD.do] - [Recode "occup_skill" and "occup"; change path to the intermediate file]
+* Date: [2022-11-07] File: [IDN_1999_Sakernas_v01_M_v04_A_GLD.do] - [Added occup based on KBJI1982 two digits and KBJI2002 one digit]
+* Date: [2023-01-12] File: [IDN_1999_Sakernas_v01_M_v05_A_GLD.do] - [Educat7 correction & directories update; Changed directories; industrycat10 updated; ISIC version changed from ISIC Rev.3 to missing; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_1999_Sakernas_v01_M_v06_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "1999"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v06"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas99.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p1-b1p10
+	egen hhid = group(b1p1-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    155,572      100.00      100.00
+------------+-----------------------------------
+      Total |    155,572      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p5
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p1
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 1999 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 1999.
+
+	But note that 17 district codes only appear in 1999 (no district labels) not in 2013: 1171 1472 3218 3219 3220 3273 6271 7271 7319 7320 7321 7371 8208 8209 8210 8211 8212. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p2
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p1
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p2
+	rename subnatid2_code b1p2
+	merge n:1 b1p2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = ""
+	replace subnatid1_prev = "32 - JAWA BARAT" if b1p1 == 36
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b3k5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b3k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b3k3
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b3k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b3k6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b3k7
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+0.Diploma IV/Bachelor/Postgraduate
+1.No/never in school
+2.No/not yet finish Primary School
+3.Primary school
+4.Public Junior High School
+5.Vocational Junior High School
+6.Public Senior High School
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy=. if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2b==1)" or
+							  "worked at least 1 hour during the last week (b4p3==1)" or
+							  "has a job but was temporarily out of work (b4p4==1)";
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p13==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p13==2)"
+
+labour force participation: 59.44%
+
+. count if !mi(b4p6a)
+  86,863
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2b==1 | b4p3==1 | b4p4==1
+	replace lstatus = 2 if lstatus != 1 & (b4p13==1)
+	replace lstatus = 3 if lstatus != 1 & (b4p13==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p19==1 & (b4p13==2)) or
+2)searching but not immediately available to work (b4p13==1) & b4p19==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p19==1 & (b4p13==2)] | [ b4p13==1 & b4p19==2 ]
+	replace potential_lf = 0 if [b4p19==1 & b4p13==1] | [ b4p13==2 & b4p19==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p18" has 7 non-missing categories:
+	1 Felt impossible to find a job
+	2 Attending school
+	3 Housekeeping
+	4 Have work/business
+	5 Feel sufficient
+	6 Unable to do work
+	7 Other, specify
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p18
+	recode nlfreason (2=1) (3=2) (6=4) (1 4 5 7=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p16" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p16
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p16
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p9 if inrange(b4p9, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p6
+	tostring industry_orig, replace
+	replace industry_orig = "" if industry_orig=="."
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10 = floor(b4p6/10)
+	replace industrycat10=10 if inrange(b4p6,92,99) 
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p7
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p7
+	recode occup_isco (55=5)
+	replace occup_isco = occup_isco*100
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if occup_isco=="."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p7
+	merge m:1 kji1982 urban using "`path_in_stata'\kji_2d_corresp.dta", keep(match master) nogen
+	* set seed so process is reproducible
+	set seed 123
+	gen helper_occup = uniform()
+	* First define cases for shorthand
+	gen cases = .
+	replace cases = 1 if missing(option_2)
+	replace cases = 2 if !missing(cp_2) & missing(cp_3)
+	replace cases = 3 if !missing(cp_3) & missing(cp_4)
+	replace cases = 4 if !missing(cp_4) & missing(cp_5)
+	replace cases = 5 if !missing(cp_5)
+* Assign occup options
+	gen occup = .
+	replace occup = option_1 if cases == 1
+	replace occup = option_1 if inrange(helper_occup,0,cp_1) & inrange(cases,2,5)
+	replace occup = option_2 if inrange(helper_occup,cp_1, cp_2) & inrange(cases,2,5)
+	replace occup = option_3 if inrange(helper_occup,cp_2, cp_3) & inrange(cases,3,5)
+	replace occup = option_3 if inrange(helper_occup,cp_3, cp_4) & inrange(cases,4,5)
+	replace occup = option_3 if inrange(helper_occup,cp_4, cp_5) & cases == 5
+	replace occup=. if lstatus!=1
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations" 10 "Armed forces" 99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p10a1 + b4p10a2
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p5b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p11==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p12
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p11!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace 
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2000_SAKERNAS/IDN_2000_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2000_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2000_SAKERNAS/IDN_2000_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2000_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1735 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2000_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					IDN_2000_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			31,439  </_Sample size (HH)_>
+<_Sample size (IND)_> 			98,952 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2000 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2000_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-24] File: [IDN_2000_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file] 
+* Date: [2023-01-11] File: [IDN_2000_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-13] File: [IDN_2000_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2000"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas00.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |     98,952      100.00      100.00
+------------+-----------------------------------
+      Total |     98,952      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = timbang
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 82 "82 - MALUKU UTARA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2000 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2000.
+
+	But note that 17 district codes only appear in 2000 (no district labels) not in 2013: 1171 1472 3218 3219 3220 3273 6271 7271 7319 7320 7321 7371 8208 8209 8210 8211 8212. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = stat
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the questionnaire:
+0.University (DIV, S-1, or above)
+1.Never/not yet in school
+2.No/not yet finish Primary School
+3.Primary school
+4.General Junior High School
+5.Vocational Junior High School
+6.General Senior High School
+7.Vocational secondary school
+8.Diploma I/II
+9.Academy D.III
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy=. if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2b==1)" or
+							  "worked at least 1 hour during the last week (b4p3==1)" or
+							  "has a job but was temporarily out of work (b4p4==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p5==2)"
+
+labour force participation: 60.25%
+
+. tab b4p6a, m
+
+      Total |
+    working |
+  day(s) of |
+   all jobs |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |      1,049        1.06        1.06
+          1 |        141        0.14        1.20
+          2 |        598        0.60        1.81
+          3 |      1,352        1.37        3.17
+          4 |      2,964        3.00        6.17
+          5 |      6,752        6.82       12.99
+          6 |     19,378       19.58       32.58
+          7 |     23,872       24.12       56.70
+          . |     42,846       43.30      100.00
+------------+-----------------------------------
+      Total |     98,952      100.00
+
+. count if !mi(b4p6a)
+  56,106
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2b==1 | b4p3==1 | b4p4==1
+	replace lstatus = 2 if lstatus != 1 & (b4p5==1)
+	replace lstatus = 3 if lstatus != 1 & (b4p5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p22==1 & b4p5==2) or
+2)searching but not immediately available to work ( b4p5==1 & b4p22==2)
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p22==1 & b4p5==2] | [ b4p5==1 & b4p22==2]
+	replace potential_lf = 0 if [b4p22==1 & b4p5==1] | [ b4p5==2 & b4p22==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p19" has 7 non-missing categories:
+	1 Felt impossible to find a job
+	2 Attending school
+	3 Housekeeping
+	4 Have work/business
+	5 Feel sufficient
+	6 Unable to do work
+	7 Other, specify
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p19
+	recode nlfreason (2=1) (3=2) (6=4) (1 4 5 7=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p17" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p17
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p17
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10, 1, 5)
+	recode empstat (1 2=4) (4=1) (5=2)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4p7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (30 531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if industrycat_isic=="."
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4p7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if occup_isco>9
+	replace occup_isco = occup_isco*100 if occup_isco<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4p8==409
+	replace occup_isco = "" if b4p8==138
+	replace occup_isco = "" if b4p8==238
+	replace occup_isco = "" if b4p8==312
+	replace occup_isco = "" if b4p8==511
+	replace occup_isco = "" if inrange(b4p8, 491, 498)
+	replace occup_isco = "" if inrange(b4p8, 647, 648)
+	replace occup_isco = "" if inrange(b4p8, 111, 112)
+	replace occup_isco = "" if inrange(b4p8, 221, 223)
+	replace occup_isco = "" if inrange(b4p8, 231, 232)
+	replace occup_isco = "" if inrange(b4p8, 241, 249)
+	replace occup_isco = "" if inrange(b4p8, 251, 255)
+	replace occup_isco = "" if inrange(b4p8, 411, 412)
+	replace occup_isco = "" if inrange(b4p8, 461, 462)
+	replace occup_isco = "" if inrange(b4p8, 614, 639)
+	replace occup_isco = "" if inrange(b4p8, 821, 829)
+	replace occup_isco = "" if inrange(b4p8, 991, 993)
+	replace occup_isco = "" if occup_isco=="."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p11a1 + b4p11a2
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p13==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p14
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p13!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2001_SAKERNAS/IDN_2001_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2001_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2001_SAKERNAS/IDN_2001_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2001_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1746 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2001_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					IDN_2001_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			38,052 </_Sample size (HH)_>
+<_Sample size (IND)_> 			119,935 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2001_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2001_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file] 
+* Date: [2023-01-11] File: [IDN_2001_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2001_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2001"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas01.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    119,935      100.00      100.00
+------------+-----------------------------------
+      Total |    119,935      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+/*<_subnatid1_note_>
+
+Note that Irian Jaya (Papua Barat/or West Papua) was assigned three codes in 1999 into which it was to be divided into. These three codes are:
+
+91 Papua West
+92 Irian Jaya Tengah
+93 Irian Jaya Timur
+
+West Papua did not split from province Papua until 2003. 94-Papua did not appear in SAKERNAS until 2003. In 2001, the raw data only has 91-Papua West. Though it has 92 and 93 yet they do not have value labels. They probably refer to Irian Jaya Tengah and Irian Jaya Timur respectively.
+
+<_subnatid1_note_>*/
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO"  81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA" 92 "92 - IRIAN JAYA TENGAH" 93 "93 - IRIAN JAYA TIMUR"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2001 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2001.
+
+	But note that 22 district codes only appear in 2001 (no district labels) not in 2013: 1171 1411 1412 1472 3273 6271 7271 7319 7320 7321 7371 9171 9201 9202 9203 9204 9205 9301 9303 9304 9371. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = ""
+	replace subnatid1_prev = "16 - SUMATERA SELATAN" if b1p01 == 19
+	replace subnatid1_prev = "32 - JAWA BARAT" if b1p01 ==36
+	replace subnatid1_prev = "71 - SULAWESI UTARA" if b1p01 ==75
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = stat
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the questionnaire:
+1.Did not attend/have not attended school
+2.Did not complete/have not completed primary school
+3.Primary school
+4.Public junior high school/TSANAWIYAH
+5.Vocational junior high school
+6.Public senior high school/ALIYAH
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+10.University/D. IV
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b4p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p4==1) | (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p4==2) & (b4p5==2)"
+
+labour force participation: 58.84%
+
+. tab b4p6a, m
+
+      Total |
+    working |
+     day(s) |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |      1,612        1.34        1.34
+          1 |        138        0.12        1.46
+          2 |        594        0.50        1.95
+          3 |      1,557        1.30        3.25
+          4 |      3,605        3.01        6.26
+          5 |      8,368        6.98       13.24
+          6 |     23,517       19.61       32.84
+          7 |     26,860       22.40       55.24
+          . |     53,684       44.76      100.00
+------------+-----------------------------------
+      Total |    119,935      100.00
+
+. count if !mi(b4p6a)
+  66,251
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2a1==1 | b4p3==1
+	replace lstatus = 2 if lstatus != 1 & [(b4p4==1) | (b4p5==1)]
+	replace lstatus = 3 if lstatus != 1 & (b4p4==2) & (b4p5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p22==1 & (b4p4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4p4==1) | (b4p5==1)] & b4p22==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p22==1 & (b4p4==2) & (b4p5==2)] | [(b4p4==1 | b4p5==1) & b4p22==2]
+	replace potential_lf = 0 if [b4p22==1 & (b4p4==1 | b4p5==1)] | [(b4p4==2 & b4p5==2) & (b4p22==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p21" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p21
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p19" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p19
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p19
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4p7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4p7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if occup_isco>9
+	replace occup_isco = occup_isco*100 if occup_isco<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4p8==409
+	replace occup_isco = "" if b4p8==138
+	replace occup_isco = "" if inrange(b4p8, 491, 498)
+	replace occup_isco = "" if inrange(b4p8, 647, 648)
+	decode b4p8, gen(label_copy)
+	replace occup_isco = "" if label_copy==""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12a + b4p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b4p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b4p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p15==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p16
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p15!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2002_SAKERNAS/IDN_2002_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2002_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2002_SAKERNAS/IDN_2002_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2002_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1724 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2002_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					IDN_2002_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			70,176 </_Sample size (HH)_>
+<_Sample size (IND)_> 			275,342 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2002_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2002_Sakernas_v01_M_v03_A_GLD.do] -[Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file]
+* Date: [2023-01-11] File: [IDN_2002_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2002_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" ; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2002"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas02.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	duplicates drop
+	sort b1r1 b1r2 b1r5 b1r7 b1r8
+	egen hhid = group(b1r1 b1r2 b1r5 b1r7 b1r8)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    275,331       99.99       99.99
+          1 |         22        0.01      100.00
+------------+-----------------------------------
+      Total |    275,353      100.00
+
+	  11 observations were dropped.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = infl
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1r5
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+/*<_subnatid1_note_>
+
+Note that Irian Jaya (Papua Barat/or West Papua) was assigned three codes in 1999 into which it was to be divided into. These three codes are:
+
+91 Papua West
+92 Irian Jaya Tengah
+93 Irian Jaya Timur
+
+West Papua did not split from province Papua until 2003. 94-Papua did not appear in SAKERNAS until 2003. In 2001, the raw data only has 91-Papua West. Though it has 92 and 93 yet they do not have value labels. They probably refer to Irian Jaya Tengah and Irian Jaya Timur respectively.
+
+<_subnatid1_note_>*/
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy = b1r1
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO"  81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA" 92 "92 - IRIAN JAYA TENGAH" 93 "93 - IRIAN JAYA TIMUR"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2002 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2002.
+
+	But note that 11 district codes only appear in 2002 (no district labels) not in 2013: 1171 1411 1412 3273 6271 7271 7319 7320 7321 7371 9171. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1r2
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1r1
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1r2
+	rename subnatid2_code b1r2
+	merge n:1 b1r2 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1r10
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b3k5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b3k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b3k3
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b3k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b3k6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b3k7
+	recode school (1 3=0) (2=1)
+	replace school=. if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4ar1a" in the questionnaire:
+0.University/D. IV
+1.Did not attend/have not attended school
+2.Did not complete/have not completed primary school
+3.Primary school
+4.Public junior high school/TSANAWIYAH
+5.Vocational junior high school
+6.Public senior high school/ALIYAH
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4ar1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4ar1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4ar1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4br2a1==1)" or
+							  "has a job but was temporarily out of work (b4br3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4br4==1) | (b4br5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4br4==2) & (b4br5==2)"
+
+labour force participation: 46.18%
+
+. tab b4br6a, m
+
+      Total |
+    working |
+     day(s) |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |      3,081        1.14        1.14
+          1 |        181        0.07        1.21
+          2 |      1,079        0.40        1.61
+          3 |      2,893        1.08        2.69
+          4 |      6,940        2.58        5.27
+          5 |     15,095        5.61       10.88
+          6 |     41,335       15.36       26.24
+          7 |     45,934       17.07       43.31
+          . |    152,562       56.69      100.00
+------------+-----------------------------------
+      Total |    269,100      100.00
+
+. count if !mi(b4br6a)
+  116,538
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4br2a1==1 | b4br3==1
+	replace lstatus = 2 if lstatus != 1 & [(b4br4==1) | (b4br5==1)]
+	replace lstatus = 3 if lstatus != 1 & (b4br4==2) & (b4br5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4er22==1 & (b4br4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4br4==1) | (b4p5==1)] & b4er22==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4er22==1 & (b4br4==2) & (b4br5==2)] | [(b4br4==1 | b4br5==1) & b4er22==2]
+	replace potential_lf = 0 if [b4er22==1 & (b4br4==1 | b4br5==1)] | [(b4br4==2 & b4br5==2) & (b4er22==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4er21" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4er21
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4er19" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4er19
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4er19
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4cr10a if inrange(b4cr10a, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4cr7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4cr7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+		gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4cr7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4cr8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4cr8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4cr8==409
+	replace occup_isco = "" if b4cr8==138
+	replace occup_isco = "" if inrange(b4cr8, 491, 498)
+	replace occup_isco = "" if inrange(b4cr8, 647, 648)
+	decode b4cr8, gen(label_copy)
+	replace occup_isco = "" if label_copy==""
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4cr8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4cr12a + b4cr12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4cr9
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b4cr10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b4cr10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4dr15==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4dr16
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4dr15!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2003_SAKERNAS/IDN_2003_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2003_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2003_SAKERNAS/IDN_2003_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2003_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1732 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2003_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					IDN_2003_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			76,085 </_Sample size (HH)_>
+<_Sample size (IND)_> 			232,466 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2003_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2003_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file]  
+* Date: [2023-01-14] File: [IDN_2003_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2003_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2003"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas03.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    232,466      100.00      100.00
+------------+-----------------------------------
+      Total |    232,466      100.00
+
+<_pid_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO"  81 "81 - MALUKU" 82 "82 - MALUKU UTARA"  94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2003 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2003.
+
+	But note that 16 district codes only appear in 2003 (no district labels) not in 2013: 1171 1411 1412 1472 1474 3273 6271 7271 7319 7320 7321 7323 7371 9405 9406 9407 9472. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = stat
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+1. No/never in school
+2. No/not yet finish Primary School
+3. Primary School
+4. Public Junior High School
+5. Vocational Junior High School 
+6. Public Senior High School
+7. Vocational Senior High School
+8. Diploma I/II
+9. Academy/Diploma III
+10. Diploma IV/Bachelor/Postgraduate
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy=. if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+}
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b4p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p4==1) | (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p4==2) & (b4p5==2)"
+
+labour force participation: 57.32%
+
+. tab b4p6a, m
+
+      Total |
+    working |
+     day(s) |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |      2,854        1.23        1.23
+          1 |        190        0.08        1.31
+          2 |        993        0.43        1.74
+          3 |      2,881        1.24        2.98
+          4 |      6,882        2.96        5.94
+          5 |     15,953        6.86       12.80
+          6 |     46,705       20.09       32.89
+          7 |     48,239       20.75       53.64
+          . |    107,769       46.36      100.00
+------------+-----------------------------------
+      Total |    232,466      100.00
+
+
+. count if !mi(b4p6a)
+  124,697
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2a1==1 | b4p3==1
+	replace lstatus = 2 if lstatus != 1 & [(b4p4==1) | (b4p5==1)]
+	replace lstatus = 3 if lstatus != 1 & (b4p4==2) & (b4p5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p22==1 & (b4p4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4p4==1) | (b4p5==1)] & b4p22==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p22==1 & (b4p4==2) & (b4p5==2)] | [(b4p4==1 | b4p5==1) & b4p22==2]
+	replace potential_lf = 0 if [b4p22==1 & (b4p4==1 | b4p5==1)] | [(b4p4==2 & b4p5==2) & (b4p22==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p21 " has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p21
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p19" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p19
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p19
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4p7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	replace industrycat_isic = "" if industrycat_isic=="."
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4p7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if occup_isco>9
+	replace occup_isco = occup_isco*100 if occup_isco<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4p8==409
+	replace occup_isco = "" if inrange(b4p8, 491, 498)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12a + b4p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b4p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b4p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p15==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p16
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p15!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2004_SAKERNAS/IDN_2004_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2004_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2004_SAKERNAS/IDN_2004_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2004_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1729 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2004_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					IDN_2004_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			75,557 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,480 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-26] File: [IDN_2004_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2004_Sakernas_v01_M_v03_A_GLD.do] -[Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file] 
+* Date: [2023-01-14] File: [IDN_2004_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2004_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2004"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas04.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    209,480      100.00      100.00
+------------+-----------------------------------
+      Total |    209,480      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO"  81 "81 - MALUKU" 82 "82 - MALUKU UTARA"  94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2004 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2004.
+
+	But note that 22 district codes only appear in 2004 (no district labels) not in 2013: 1171 1411 1412 1472 1474 3273 6271 7271 7319 7320 7321 7323 7324 7371 9405 9406 9407 9415 9422 9424 9425 9472. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = stat
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school=. if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+1.Did not attend/have not attended school
+2.Did not complete/have not completed primary school
+3.Primary school
+4.Public junior high school/TSANAWIYAH
+5.Vocational junior high school
+6.Public senior high school/ALIYAH
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+10.Diploma IV/Bachelor/Postgraduate
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b4p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p4==1) | (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p4==2) & (b4p5==2)"
+
+labour force participation: 65.06%
+
+. tab b4p6a, m
+
+    working |
+     day(s) |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |      2,952        1.37        1.37
+          1 |        306        0.14        1.51
+          2 |      1,370        0.63        2.14
+          3 |      3,152        1.46        3.61
+          4 |      7,207        3.34        6.95
+          5 |     14,631        6.78       13.73
+          6 |     42,372       19.64       33.36
+          7 |     48,261       22.37       55.73
+          . |     95,524       44.27      100.00
+------------+-----------------------------------
+      Total |    215,775      100.00
+
+. count if !mi(b4p6a)
+  127,119
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2a1==1 | b4p3==1
+	replace lstatus = 2 if lstatus != 1 & [(b4p4==1) | (b4p5==1)]
+	replace lstatus = 3 if lstatus != 1 & (b4p4==2) & (b4p5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p22==1 & (b4p4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4p4==1) | (b4p5==1)] & b4p22==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p22==1 & (b4p4==2) & (b4p5==2)] | [(b4p4==1 | b4p5==1) & b4p22==2]
+	replace potential_lf = 0 if [b4p22==1 & (b4p4==1 | b4p5==1)] | [(b4p4==2 & b4p5==2) & (b4p22==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p21" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p21
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p19" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p19
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p19
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=.  if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4p7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	replace industrycat_isic = "" if industrycat_isic=="."
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4p7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig=b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>	
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if occup_isco>9
+	replace occup_isco = occup_isco*100 if occup_isco<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4p8==409
+	replace occup_isco = "" if b4p8==138
+	replace occup_isco = "" if inrange(b4p8, 491, 498)
+	replace occup_isco = "" if inrange(b4p8, 647, 648)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12a + b4p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b4p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b4p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p15==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p16
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p15!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2005_SAKERNAS/IDN_2005_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2005_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2005_SAKERNAS/IDN_2005_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2005_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1722 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2005_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					IDN_2005_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			68,645 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,775 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2005_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2005_Sakernas_v01_M_v03_A_GLD.do] -[Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file]  
+* Date: [2023-01-13] File: [IDN_2005_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2005_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2005"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas05feb.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID with
+// b1p01 = province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    215,775      100.00      100.00
+------------+-----------------------------------
+      Total |    215,775      100.00
+
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = weiht10
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO"  81 "81 - MALUKU" 82 "82 - MALUKU UTARA"  94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2005 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2005.
+
+	But note that 21 district codes only appear in 2005 (no district labels) not in 2013: 1171 2171 3273 6271 7271 7319 7320 7321 7323 7324 7371 9405 9406 9407 9415 9421 9422 9423 9424 9425 9472. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = ""
+	replace subnatid1_prev = "14 - RIAU" if b1p01 == 21
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p12
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school=. if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+0.University/D. IV
+1.Did not attend/have not attended school
+2.Did not complete/have not completed primary school
+3.Primary school
+4.Public junior high school/TSANAWIYAH
+5.Vocational junior high school
+6.Public senior high school/ALIYAH
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy=. if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (0=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b4p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p4==1) | (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p4==2) & (b4p5==2)"
+
+labour force participation: 59.09%
+
+. tab b4p6a, m
+
+    working |
+     day(s) |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |      2,952        1.37        1.37
+          1 |        306        0.14        1.51
+          2 |      1,370        0.63        2.14
+          3 |      3,152        1.46        3.61
+          4 |      7,207        3.34        6.95
+          5 |     14,631        6.78       13.73
+          6 |     42,372       19.64       33.36
+          7 |     48,261       22.37       55.73
+          . |     95,524       44.27      100.00
+------------+-----------------------------------
+      Total |    215,775      100.00
+
+. count if !mi(b4p6a)
+  120,251
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b4p2a1==1 | b4p3==1
+	replace lstatus = 2 if lstatus != 1 & [(b4p4==1) | (b4p5==1)]
+	replace lstatus = 3 if lstatus != 1 & (b4p4==2) & (b4p5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p22==1 & (b4p4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4p4==1) | (b4p5==1)] & b4p22==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p22==1 & (b4p4==2) & (b4p5==2)] | [(b4p4==1 | b4p5==1) & b4p22==2]
+	replace potential_lf = 0 if [b4p22==1 & (b4p4==1 | b4p5==1)] | [(b4p4==2 & b4p5==2) & (b4p22==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p21" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p21
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p14b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p14b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p14b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4p7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	replace industrycat_isic = "" if industrycat_isic=="."
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4p7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if occup_isco>9
+	replace occup_isco = occup_isco*100 if occup_isco<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4p8==409
+	replace occup_isco = "" if inrange(b4p8, 491, 498)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12a + b4p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b4p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b4p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p15==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p16
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p15!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2006_SAKERNAS/IDN_2006_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2006_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2006_SAKERNAS/IDN_2006_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2006_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1710 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2006_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					IDN_2006_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			70,836 </_Sample size (HH)_>
+<_Sample size (IND)_> 			193,696 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2000 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2006_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2006_Sakernas_v01_M_v03_A_GLD.do] -[Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; recode "occup_skill" and "occup"; change path to the intermediate file]  
+* Date: [2023-01-17] File: [IDN_2006_Sakernas_v01_M_v04_A_GLD.do] - [Educat7 correction & directories update; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"] 
+* Date: [2023-03-12] File: [IDN_2006_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]    
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2006"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas06aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID
+// with prop= province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	rename prop b1p01
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    193,696      100.00      100.00
+------------+-----------------------------------
+      Total |    193,696      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2006 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2006.
+
+	But note that 13 district codes only appear in 2006 (no district labels) not in 2013: 1171 2001 2002 2003 2004 2071 2072 3272 3273 6271 7271 7371 9171 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = ""
+	replace subnatid1_prev = "73 - SULAWESI SELATAN" if b1p01 == 76
+	replace subnatid1_prev = "94 - PAPUA" if b1p01 == 91
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen hsize = b1p13
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+0.Did not attend/have not attended school
+1.Did not complete/have not completed primary school
+2.Primary school
+3.Junior high school/TSANAWIYAH
+4.Vocational junior high school
+5.Senior high school/ALIYAH
+6.Vocational school
+7.Diploma I/II
+8.Diploma III
+9.Diploma IV/Bachelor/Postgraduate
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (0=1) (1=2) (2=3) (3/4=4) (5/6=5) (7 8=6) (9=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (0=660) (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b4p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p4==1) | (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p4==2) & (b4p5==2)"
+
+labour force participation: 64.79%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if !inlist(b4p6a, ., 0)
+	replace lstatus = 2 if lstatus != 1 & [(b4p4==1) | (b4p5==1)]
+	replace lstatus = 3 if lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p24==1 & (b4p4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4p4==1) | (b4p5==1)] & b4p24==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p24==1 & (b4p4==2) & (b4p5==2)] | [(b4p4==1 | b4p5==1) & b4p24==2]
+	replace potential_lf = 0 if [b4p24==1 & (b4p4==1 | b4p5==1)] | [(b4p4==2 & b4p5==2) & (b4p24==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p21" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p21
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p14b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p14b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p14b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p10 if inrange(b4p10 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = b4p7
+	recode industrycat_isic (101 102=100) (174=170) (262/266=260) (531/549 000 268 625=.) (631/639=630) (703=700)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	replace industrycat_isic = "" if industrycat_isic=="."
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen industrycat10_str = substr(industrycat_isic, 1, 2)
+	destring industrycat10_str, replace
+	gen byte industrycat10 = industrycat10_str
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (75/99=10)
+	replace industrycat10 = 6 if inrange(b4p7, 531, 549)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = b4p8
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/329=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if occup_isco>9
+	replace occup_isco = occup_isco*100 if occup_isco<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if b4p8==409
+	replace occup_isco = "" if inrange(b4p8, 491, 498)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_>
+	gen kji1982 = b4p8
+	merge m:1 kji1982 urban using "`path_in_stata'\occup.dta", keep (match master) nogen
+	set seed 123
+	gen helper_occup = uniform()
+	gen occup = .
+	replace occup = option_1 if !missing(kji1982) & probs_1 == 1
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & helper_occup > probs_1 & missing(probs_3)
+	
+	replace occup = option_1 if !missing(kji1982) & probs_1 < 1 & helper_occup <= probs_1 & !missing(probs_3)
+	replace occup = option_2 if !missing(kji1982) & probs_1 < 1 & (helper_occup > probs_1 & helper_occup <= (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = option_3 if !missing(kji1982) & probs_1 < 1 & (helper_occup > (probs_1 + probs_2)) & !missing(probs_3)
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_occup_skill_>
+	gen occup_skill=occup
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p12a + b4p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b4p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b4p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p15==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p16
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p15!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2007_SAKERNAS/IDN_2007_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2007_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2007_SAKERNAS/IDN_2007_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2007_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1692 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2007_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					IDN_2007_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			286,048 </_Sample size (HH)_>
+<_Sample size (IND)_> 			910,277 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2002 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2005 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2007_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2007_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-17] File: [IDN_2007_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2007_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2007"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas07aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID
+// with b1p01= province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p10
+	egen hhid = group(b1p01-b1p10)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    910,277      100.00      100.00
+------------+-----------------------------------
+      Total |    910,277      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = .
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2007 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2007.
+
+	But note that 8 district codes only appear in 2007 (no district labels) not in 2013: 1171 2171 3273 6271 7271 7371 9171 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	bys hhid: egen hsize = max(no)
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b4p1a" in the dataset:
+1.Did not attend/have not attended school
+2.Did not complete/have not completed primary school
+3.Primary school
+4.Public junior high school/TSANAWIYAH
+5.Vocational junior high school
+6.Senior high school/ALIYAH
+7.Vocational school
+8.Diploma I/II
+9.Diploma III
+10.Diploma IV/S1/S2
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b4p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b4p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b4p1a
+	recode educat_isced (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550) (10=660)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b4p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b4p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b4p4==1) | (b4p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b4p4==2) & (b4p5==2)"
+
+labour force participation: 58.04% (64.69% age above 14)
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if !inlist(b4p6a, ., 0)
+	replace lstatus = 2 if lstatus != 1 & [(b4p4==1) | (b4p5==1)]
+	replace lstatus = 3 if lstatus ==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b4p24==1 & (b4p4==2) & (b4p5==2)) or
+2)searching but not immediately available to work [(b4p4==1) | (b4p5==1)] & b4p24==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b4p24==1 & (b4p4==2) & (b4p5==2)] | [(b4p4==1 | b4p5==1) & b4p24==2]
+	replace potential_lf = 0 if [b4p24==1 & (b4p4==1 | b4p5==1)] | [(b4p4==2 & b4p5==2) & (b4p24==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b4p23" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b4p23
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b4p15b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b4p15b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b4p15b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b4p11a if inrange(b4p11a , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b4p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	tostring b4p7, gen(b4p7_str) format(%05.0f)
+	gen industrycat_isic2 = substr(b4p7_str, 1, 2)
+	destring industrycat_isic2, gen (industrycat_num)
+	replace industrycat_num = 52 if industrycat_num==53|industrycat_num==54
+	gen industrycat_isic = industrycat_num*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = industrycat_num
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (80/99=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b4p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	tostring b4p8, gen(occup_isco3)
+	replace occup_isco3 = substr(occup_isco3, 1, 3)
+	destring occup_isco3, gen(occup_isco)
+	recode occup_isco (24=23) (23 231=244) (241=231) (242=232) (243=233) (244 246=235) (245=234) (25 251=242) (110/190=110) (26 261=241) (291=243) (292=245) (293=246) (29=24) (331=333) (332=33) (34=341) (35 351=342) (39=34) (391=343) (392=344) (393=345) (394=346) (395=347) (396=348)
+	replace occup_isco = occup_isco*10 if occup_isco>99
+	replace occup_isco = occup_isco*100 if occup_isco<100
+	tostring occup_isco, format(%04.0f) replace
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = substr(occup_isco3, 1, 1)
+	destring occup_skill, replace
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco3, 1, 1)
+	destring occup, replace
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b4p13a + b4p13b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b4p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b4p17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b4p18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b4p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2008_SAKERNAS/IDN_2008_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2008_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2008_SAKERNAS/IDN_2008_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2008_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1691 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2008_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					IDN_2008_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			291,656</_Sample size (HH)_>
+<_Sample size (IND)_> 			931,890 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2002 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2005 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2008_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-23] File: [IDN_2008_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-17] File: [IDN_2008_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2008_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2008"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas08aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+/*<_hhid_note_>
+
+Following codes given by the "A guide to working with Indonesian survey data":
+
+// create household ID
+// with b1p01= province
+// b1p02= district/city
+// b1p03= sub-district
+// b1p04= village/kelurahan
+// b1p05= village/kelurahan classification
+(urban/rural)
+// b1p07= sample code number
+// b1p10= household sample sequential number
+
+But in 2008, sub-district and village/kelurahan are unavailable and household sample sequential number is coded as b1p08.
+
+<_hhid_note_>*/
+
+
+*<_hhid_>
+	sort b1p01-b1p08
+	egen hhid = group(b1p01-b1p08)
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    931,890      100.00      100.00
+------------+-----------------------------------
+      Total |    931,890      100.00
+
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = weight08
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2008 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2008.
+
+	But note that 8 district codes only appear in 2008 (no district labels) not in 2013: 1171 2171 3273 6271 7271 7371 9171 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2p01
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b5p1a" in the dataset:
+1.No/never in school
+2.No/not yet finish primary school
+3.Primary school
+4.Junior high school
+5.Vocational junior high school
+6.Senior high school
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+10.Diploma IV/S1
+11.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10/11=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5p1a
+	recode educat_isced (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550) (10=660) (11=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5p2a1 ==1)" or
+							  "has a job but was temporarily out of work (b5p3==1)"; (this was defined by the questionnaire)
+unemployed: "who do not have a job/business lstatus != 1" & "seeking a job (b5p4==1) | (b5p5==1)"
+non-labor force:  "who do not have a job/business lstatus != 1" & "not seeking a job (b5p4==2) & (b5p5==2)"
+
+labour force participation: 58.82% (64.57% age above 14)
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if !inlist(b5p6a, ., 0)
+	replace lstatus = 2 if lstatus != 1 & [(b5p4==1) | (b5p5==1)]
+	replace lstatus = 3 if lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5p24==1 & (b5p4==2) & (b5p5==2)) or
+2)searching but not immediately available to work [(b5p4==1) | (b5p5==1)] & b5p24==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5p24==1 & (b5p4==2) & (b5p5==2)] | [(b5p4==1 | b5p5==1) & b5p24==2]
+	replace potential_lf = 0 if [b5p24==1 & (b5p4==1 | b5p5==1)] | [(b5p4==2 & b5p5==2) & (b5p24==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5p23" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5p23
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5p16b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5p16b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5p16b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5p10a if inrange(b5p10a , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b5p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	tostring b5p7, gen(b5p7_str) format(%05.0f)
+	gen industrycat_isic2 = substr(b5p7_str, 1, 2)
+	destring industrycat_isic2, gen (industrycat_num)
+	replace industrycat_num = 52 if industrycat_num==53|industrycat_num==54
+	gen industrycat_isic = industrycat_num*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = industrycat_num
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (80/99=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b5p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	tostring b5p8, gen(occup_isco3)
+	replace occup_isco3 = substr(occup_isco3, 1, 3)
+	destring occup_isco3, gen(occup_isco)
+	recode occup_isco (24=23) (23 231=244) (241=231) (242=232) (243=233) (244 246=235) (245=234) (25 251=242) (110/190=110) (26 261=241) (291=243) (292=245) (293=246) (29=24) (331=333) (332=33) (34=341) (35 351=342) (39=34) (391=343) (392=344) (393=345) (394=346) (395=347) (396=348)
+	replace occup_isco = occup_isco*10 if occup_isco>99
+	replace occup_isco = occup_isco*100 if occup_isco<100
+	tostring occup_isco, format(%04.0f) replace
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = substr(occup_isco3, 1, 1)
+	destring occup_skill, replace
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco3, 1, 1)
+	destring occup, replace
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5p12a + b5p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b5p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b5p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5p17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5p18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b5p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2009_SAKERNAS/IDN_2009_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2009_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2009_SAKERNAS/IDN_2009_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2009_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1686 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2009_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					IDN_2009_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			926,538 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2002 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2005 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2009_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-22] File: [IDN_2009_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-17] File: [IDN_2009_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2009_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2009"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas09aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2009"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    926,538      100.00      100.00
+------------+-----------------------------------
+      Total |    926,538      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = weight
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2009 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2009.
+
+	But note that 8 district codes only appear in 2009 (no district labels) not in 2013: 1171 2171 3273 6271 7271 7371 9171 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2p01
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b5p1a" in the dataset:
+1.No/never in school
+2.No/not yet finish primary school
+3.Primary school
+4.Junior high school
+5.Vocational junior high school
+6.Senior high school
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+10.Diploma IV/S1
+11.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10/11=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5p1a
+	recode educat_isced (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550) (10=660) (11=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5p2a1==1)" ;
+unemployed: "who do not have a job/business b5p2b!=1 & b5p3==2" & "seeking a job (b5p4==1) | (b5p5==1)"
+non-labor force:  "who do not have a job/business b5p2b!=1 & b5p3==2" & "not seeking a job (b5p4==2) & (b5p5==2)"
+
+labour force participation: 53.55% (64.18% age above 15)
+
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b5p2a1==1
+	replace lstatus = 2 if lstatus!=1 & [(b5p4==1) | (b5p5==1)]
+	replace lstatus = 3 if lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5p23==1 & (b5p4==2) & (b5p5==2)) or
+2)searching but not immediately available to work [(b5p4==1) | (b5p5==1)] & b5p23==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5p23==1 & (b5p4==2) & (b5p5==2)] | [(b5p4==1 | b5p5==1) & b5p23==2]
+	replace potential_lf = 0 if [b5p23==1 & (b5p4==1 | b5p5==1)] | [(b5p4==2 & b5p5==2) & (b5p23==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5p22" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5p22
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5p15b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5p15b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5p15b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5p10a if inrange(b5p10a , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b5p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+/*<_industrycat_isic_note_>
+
+The original industrial classification used in 2009, "b5p7", is KBLI 2005 which is based on KBLI 2000.
+
+We do not have any information on translating KBLI 2005 to ISIC. Therefore, we only provided the original 5-digit code here.
+
+<_industrycat_isic_note_>*/
+
+
+*<_industrycat_isic_>
+	tostring b5p7, gen(b5p7_str) format(%05.0f)
+	gen industrycat_isic2 = substr(b5p7_str, 1, 2)
+	destring industrycat_isic2, gen (industrycat_num)
+	replace industrycat_num = 52 if industrycat_num==53|industrycat_num==54
+	gen industrycat_isic = industrycat_num*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = industrycat_num
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (80/99=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b5p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	tostring b5p8, gen(occup_isco3)
+	replace occup_isco3 = substr(occup_isco3, 1, 3)
+	destring occup_isco3, gen(occup_isco)
+	recode occup_isco (24=23) (23 231=244) (241=231) (242=232) (243=233) (244 246=235) (245=234) (25 251=242) (110/190=110) (26 261=241) (291=243) (292=245) (293=246) (29=24) (331=333) (332=33) (34=341) (35 351=342) (39=34) (391=343) (392=344) (393=345) (394=346) (395=347) (396=348)
+	replace occup_isco = occup_isco*10 if occup_isco>99
+	replace occup_isco = occup_isco*100 if occup_isco<100
+	tostring occup_isco, format(%04.0f) replace
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = substr(occup_isco3, 1, 1)
+	destring occup_skill, replace
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco3, 1, 1)
+	destring occup, replace
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5p12a + b5p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b5p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b5p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5p16==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5p17
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	tostring industrycat_isic_2, replace format(%03.0f)
+	replace industrycat_isic_2= "" if b5p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2010_SAKERNAS/IDN_2010_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2010_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2010_SAKERNAS/IDN_2010_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2010_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1695 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2010_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					IDN_2010_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			930,436 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2002 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.3 </_ISIC Version_>
+<_INDUS National_>				KBLI 2005 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2010_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-22] File: [IDN_2010_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-17] File: [IDN_2010_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; added "secondary incomplete to "educat7"]
+* Date: [2023-03-12] File: [IDN_2010_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2010"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas10aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    913,429       95.83       95.83
+          1 |     26,524        2.78       98.61
+          2 |      7,626        0.80       99.41
+          3 |      3,132        0.33       99.74
+          4 |      1,325        0.14       99.88
+          5 |        540        0.06       99.94
+          6 |        273        0.03       99.97
+          7 |         88        0.01       99.98
+          8 |         54        0.01       99.98
+          9 |         20        0.00       99.98
+         10 |         11        0.00       99.98
+         11 |         12        0.00       99.99
+         22 |         23        0.00       99.99
+         24 |         50        0.01       99.99
+         29 |         30        0.00      100.00
+         34 |         35        0.00      100.00
+------------+-----------------------------------
+      Total |    953,172      100.00
+
+Because we do not know the reason for these duplicates and they only account for less than 3% of total sample, I just droppred 22,736 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = weight
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2010 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2010.
+
+	But note that 10 district codes only appear in 2010 (no district labels) not in 2013: 1171 1572 2171 3273 6271 7271 7371 9171 9110 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2p01
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinishednote_ to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the senior seconddary level.
+
+Original code list of variable "b5p1a" in the dataset:
+1.No schooling
+2.No/not yet finish primary school
+3.Primary school/Ibtidaiyah/A package
+4.Junior high school/Tsnawiyah/B package
+5.Vocational junior high school
+6.Senior high school/Aliyah/C package
+7.Vocational senior high school
+8.Diploma I/II
+9.Diploma III
+10.Diploma IV/S1
+11.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5p1a
+	recode educat7 (4/5=4) (6/7=5) (8/9=6) (10/11=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5p1a
+	recode educat_isced (1=020) (2/3=100) (4/5=244) (6/7=344) (8=454) (9=550) (10=660) (11=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5p2b==1)" or
+							  "has a job but was temporarily out of work (b5p3==1)" or
+							  "employed but was temporarily out of work because of certain reasons (b5p22==5)";
+unemployed: "who do not have a job/business b5p2b!=1 & b5p3==2" & "seeking a job (b5p4==1) | (b5p5==1)"
+non-labor force:  "who do not have a job/business b5p2b!=1 & b5p3==2" & "not seeking a job (b5p4==2) & (b5p5==2)"
+
+labour force participation: 59.86% (65.78% age above 15)
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b5p2a1==1
+	replace lstatus = 2 if lstatus!=1 & [(b5p4==1) | (b5p5==1)]
+	replace lstatus = 3 if lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5p23==1 & (b5p4==2) & (b5p5==2)) or
+2)searching but not immediately available to work [(b5p4==1) | (b5p5==1)] & b5p23==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5p23==1 & (b5p4==2) & (b5p5==2)] | [(b5p4==1 | b5p5==1) & b5p23==2]
+	replace potential_lf = 0 if [b5p23==1 & (b5p4==1 | b5p5==1)] | [(b5p4==2 & b5p5==2) & (b5p23==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5p22" has 8 non-missing categories:
+	1 Felt impossible to find a job
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Have work/business
+	6 Feel sufficient
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5p22
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5p15b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5p15b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5p15b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5p10a if inrange(b5p10a , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = b5p7
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	tostring b5p7, gen(b5p7_str) format(%05.0f)
+	gen industrycat_isic2 = substr(b5p7_str, 1, 2)
+	destring industrycat_isic2, gen (industrycat_num)
+	replace industrycat_num = 52 if industrycat_num==53|industrycat_num==54
+	gen industrycat_isic = industrycat_num*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = industrycat_num
+	recode industrycat10 (1/5=1) (10/14=2) (15/37=3) (40/41=4) (45=5) (50/55=6) (60/64=7) (65/74=8) (75=9) (80/99=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = b5p8
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	tostring b5p8, gen(occup_isco3)
+	replace occup_isco3 = substr(occup_isco3, 1, 3)
+	destring occup_isco3, gen(occup_isco)
+	recode occup_isco (24=23) (23 231=244) (241=231) (242=232) (243=233) (244 246=235) (245=234) (25 251=242) (110/190=110) (26 261=241) (291=243) (292=245) (293=246) (29=24) (331=333) (332=33) (34=341) (35 351=342) (39=34) (391=343) (392=344) (393=345) (394=346) (395=347) (396=348)
+	replace occup_isco = occup_isco*10 if occup_isco>99
+	replace occup_isco = occup_isco*100 if occup_isco<100
+	tostring occup_isco, format(%04.0f) replace
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = substr(occup_isco3, 1, 1)
+	destring occup_skill, replace
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco3, 1, 1)
+	destring occup, replace
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5p12a + b5p12b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5p6b
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b5p10b
+	recode firmsize_l (1=0) (2=5) (3=20)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b5p10b
+	recode firmsize_u (1=4) (2=19) (3=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5p16==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5p17
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = ""
+	replace industrycat_isic_2= "" if b5p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2011_SAKERNAS/IDN_2011_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2011_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2011_SAKERNAS/IDN_2011_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2011_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1703 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2011_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					IDN_2011_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			504,997 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.4 </_ISIC Version_>
+<_INDUS National_>				KBLI 2009 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2011_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-20] File: [IDN_2011_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-17] File: [IDN_2011_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; educat7 added category 4; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2011_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2" ; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2011"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sak_aug2011_backcast.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_4"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    491,909       93.73       93.73
+          1 |     18,904        3.60       97.33
+          2 |      6,276        1.20       98.53
+          3 |      3,256        0.62       99.15
+          4 |      1,860        0.35       99.50
+          5 |      1,086        0.21       99.71
+          6 |        462        0.09       99.80
+          7 |        368        0.07       99.87
+          8 |        288        0.05       99.92
+          9 |        120        0.02       99.95
+         10 |         77        0.01       99.96
+         11 |         72        0.01       99.97
+         12 |         13        0.00       99.98
+         13 |         28        0.01       99.98
+         15 |         16        0.00       99.99
+         16 |         17        0.00       99.99
+         17 |         18        0.00       99.99
+         19 |         40        0.01      100.00
+------------+-----------------------------------
+      Total |    524,810      100.00
+
+Because we do not know the reason for these duplicates and they only account for 3.78% of total sample, I just droppred 19,813 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates tag, gen(dup)
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = weightbc
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 65 "65 - KALIMANTAN UTARA" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+	Because SAKERNAS 2011 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2010.
+
+	But note that 10 district codes only appear in 2011 (no district labels) not in 2013: 1171 1572 2171 3273 6271 7271 7371 9171 9110 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	gen code_kab = b1p02
+	tostring code_kab, format(%02.0f) replace
+	gen code_prop = b1p01
+	tostring code_prop, replace
+	gen subnatid2_code = code_prop + code_kab
+	drop b1p02
+	rename subnatid2_code b1p02
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = ""
+	replace subnatid1_prev = "64 - KALIMANTAN TIMUR" if subnatid1=="65 - KALIMANTAN UTARA"
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = .
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (2 3=1) (1 4=0)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the primary school level.
+
+Original code list of variable "b5p1a" in the dataset:
+
+1.No schooling
+2.Incompleted primary school
+3.Primary school
+4.Package A
+5.General Junior high shool
+6.Vocational Junior High School
+7.Package B
+8.General Senior High School
+9.Vocational Senior High School
+10.Package C
+11.Diploma I/II
+12.Diploma III
+13.DIV/S1
+14.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5p1a
+	recode educat7 (4=3) (5/7=4) (8/10=5) (11/12=6) (13/14=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5p1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/10=344) (11=454) (12=550) (13=660) (14=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5p2a1==1)" or
+							  "has a job but was temporarily out of work (b5p3==1)" ;
+unemployed: "who do not have a job/business mi(lstatus)" & "seeking a job (b5p4==1) | (b5p5==1)"
+non-labor force:  "who do not have a job/business mi(lstatus)" & "not seeking a job (b5p4==2) & (b5p5==2)"
+
+Labour force participation: 67.75%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b5p2a1 == 1 | b5p3 == 1
+	replace lstatus = 2 if mi(lstatus) & [(b5p4==1) | (b5p5==1)]
+	replace lstatus = 3 if mi(lstatus) & (b5p4==2) & (b5p5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5p7==1 & (b5p4==2) & (b5p5==2)) or
+2)searching but not immediately available to work [(b5p4==1) | (b5p5==1)] & b5p7==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5p7==1 & (b5p4==2) & (b5p5==2)] | [(b5p4==1 | b5p5==1) & b5p7==2]
+	replace potential_lf = 0 if [b5p7==1 & (b5p4==1 | b5p5==1)] | [(b5p4==2 & b5p5==2) & (b5p7==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5p6" has 8 non-missing categories:
+	1 Discouraged
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Already have a job
+	6 Sufficient income
+	7 Unable to do work
+	8 Other, specify
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5p6
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5p21b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5p21b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5p21b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5p12 if inrange(b5p12 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Note that in the raw dataset, two industrial classification variables, "kbli2009_2" and "b5p18", seem to represent industry of main job and industry of the main additional job respectively. "kbli2009_2" has 2 digits whereas "b5p18" has 5 digits. Both have no labels.
+
+"b5p18" is for question No.18 asking the industry of main additional job undoubtedly, leaving "kbli2009_2" used for industry of the main job, as the values are not the same if they were both for main additional job.
+
+Moreover, most cases are that people only have kbli2009_2 while they do not have b5p18.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = kbli2009_2
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = kbli2009_2
+	replace industrycat_isic = industrycat_isic*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = kbli2009_2
+	recode industrycat10 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = kji1982
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = kji1982
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/324=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if kji1982>9
+	replace occup_isco = occup_isco*100 if kji1982<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = kbji2002
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = kbji2002
+	replace occup = . if lstatus!=1
+	replace occup = . if  occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5p13a + b5p13b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5p11
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5p17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5p18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = int(b5p18/100)
+	replace industrycat_isic_2 = industrycat_isic_2*10
+	tostring industrycat_isic_2, replace format(%04.0f)
+	gen kbli2 = int(b5p18/100)
+	gen kbli4 = int(b5p18/10)
+	replace industrycat_isic_2 = "0720" if kbli2==73
+	replace industrycat_isic_2 = "4920" if kbli2==494
+	replace industrycat_isic_2 = "5520" if kbli4==5519
+	replace industrycat_isic_2 = "8550" if kbli4==8560
+	replace industrycat_isic_2 = "9600" if inlist(kbli2, 961, 962, 969)
+	replace industrycat_isic_2= "" if b5p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen industrycat10_2 = substr(industrycat_isic_2, 1, 2)
+	destring industrycat10_2, replace
+	recode industrycat10_2 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	replace industrycat10_2= . if b5p17!=1
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2012_SAKERNAS/IDN_2012_SAKERNAS_v02_M_v04_A_GLD/Programs/IDN_2012_Sakernas_v02_M_v04_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2012_SAKERNAS/IDN_2012_SAKERNAS_v02_M_v04_A_GLD/Programs/IDN_2012_Sakernas_v02_M_v04_A_GLD_ALL.do
@@ -1,0 +1,1694 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2012_Sakernas_v02_M_v04_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					IDN_2012_Sakernas_v02_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			489,146 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.4 </_ISIC Version_>
+<_INDUS National_>				KBLI 2009 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2012_Sakernas_v02_M_v01_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO & using backcasting data]
+* Date: [2022-08-20] File: [IDN_2012_Sakernas_v02_M_v02_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-12] File: [IDN_2012_Sakernas_v02_M_v03_A_GLD.do] - [Change directories; educat7 added category 4; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2012_Sakernas_v02_M_v04_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2"; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2012"
+local survey  "SAKERNAS"
+local vermast "v02"
+local veralt  "v04"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sak_aug2012_backcast.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_4"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    477,021       93.95       93.95
+          1 |     17,510        3.45       97.40
+          2 |      6,039        1.19       98.59
+          3 |      2,980        0.59       99.18
+          4 |      1,655        0.33       99.51
+          5 |        852        0.17       99.67
+          6 |        679        0.13       99.81
+          7 |        400        0.08       99.89
+          8 |        225        0.04       99.93
+          9 |         50        0.01       99.94
+         10 |         44        0.01       99.95
+         11 |         96        0.02       99.97
+         12 |        117        0.02       99.99
+         13 |         14        0.00       99.99
+         14 |         15        0.00      100.00
+         15 |         16        0.00      100.00
+------------+-----------------------------------
+      Total |    507,713      100.00
+
+Because we do not know the reason for these duplicates and they only account for less than 4% of total sample, I just droppred 18,505 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = weightbc
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+/*<_subnatid2_note_>
+
+Because SAKERNAS 2012 does not have the district name variable as other years, yet it has the same districts surveyed in 2013. Therefore, I used districts' names and codes in 2013 to codify subnatid2 in 2012.
+
+But note that 10 district codes only appear in 2012 not in 2013: 1171 1572 2171 3273 6271 7271 7371 9171 9110 9415. These districts' names were left missing.
+
+*<_subnatid2_note_>*/
+
+
+*<_subnatid2_>
+	tostring b1p02k, gen(b1p02)
+	merge n:1 b1p02 using "`path_in_stata'\district_list_2013.dta"
+	drop if _merge==2
+	drop _merge nkab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = .
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (2 3=1) (1 4=0)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the primary school level.
+
+Original code list of variable "b5p1a" in the dataset:
+1.No schooling
+2.Incompleted primary school
+3.Primary school
+4.Package A
+5.General Junior high shool
+6.Vocational Junior High School
+7.Package B
+8.General Senior High School
+9.Vocational Senior High School
+10.Package C
+11.Diploma I/II
+12.Diploma III
+13.DIV/S1
+14.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5p1a
+	recode educat7 (4=3) (5/7=4) (8/10=5) (11/12=6) (13/14=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5p1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/10=344) (11=454) (12=550) (13=660) (14=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5p2b==1)" or
+							  "has a job but was temporarily out of work (b5p3==1)" or
+							  "employed but was temporarily out of work because of certain reasons (b5p6==5)";
+unemployed: "who do not have a job/business b5p2b!=1 & b5p3==2" & "seeking a job (b5p4==1) | (b5p5==1)"
+non-labor force:  "who do not have a job/business b5p2b!=1 & b5p3==2" & "not seeking a job (b5p4==2) & (b5p5==2)"
+
+labour force participation: 63.87% (69.47% age above 14)
+*b5p2b==1 | b5p3==1 | b5p6==5
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if 0<b5p8a & b5p8a<.
+	replace lstatus = 2 if lstatus!=1 & [(b5p4==1) | (b5p5==1)]
+	replace lstatus = 3 if lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5p7==1 & (b5p4==2) & (b5p5==2)) or
+2)searching but not immediately available to work [(b5p4==1) | (b5p5==1)] & b5p7==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5p7==1 & (b5p4==2) & (b5p5==2)] | [(b5p4==1 | b5p5==1) & b5p7==2]
+	replace potential_lf = 0 if [b5p7==1 & (b5p4==1 | b5p5==1)] | [(b5p4==2 & b5p5==2) & (b5p7==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5p6" has 8 non-missing categories:
+	1 Discouraged
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Already have a job
+	6 Sufficient income
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5p6
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5p21b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5p21b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5p21b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5p12 if inrange(b5p12 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Note that in the raw dataset, two industrial classification variables, "kbli2009_2" and "b5p18", seem to represent industry of main job and industry of the main additional job respectively. "b5p18" has 5 digits whereas "kbli2009_2" has 2 digits. Both have no labels.
+
+"b5p18" is for question No.18 asking the industry of main additional job undoubtedly, leaving "kbli2009_2" used for industry of the main job, as the values are not the same if they were both for main additional job.
+
+Moreover, most cases are that people only have kbli2009_2 while they do not have b5p18.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = kbli2009_2
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = kbli2009_2
+	replace industrycat_isic = industrycat_isic*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = kbli2009_2
+	recode industrycat10 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = kji1982
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = kji1982
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/324=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if kji1982>9
+	replace occup_isco = occup_isco*100 if kji1982<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = kbji2002
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = kbji2002
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5p13a + b5p13b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5p11
+	replace whours = . if lstatus!=1
+	replace whours = . if whours == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5p17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5p18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = int(b5p18/100)
+	replace industrycat_isic_2 = industrycat_isic_2*10
+	tostring industrycat_isic_2, replace format(%04.0f)
+	gen kbli2 = int(b5p18/100)
+	gen kbli4 = int(b5p18/10)
+	replace industrycat_isic_2 = "0720" if kbli2==73
+	replace industrycat_isic_2 = "4920" if kbli2==494
+	replace industrycat_isic_2 = "5520" if kbli4==5519
+	replace industrycat_isic_2 = "8550" if kbli4==8560
+	replace industrycat_isic_2 = "9600" if inlist(kbli2, 961, 962, 969)
+	replace industrycat_isic_2= "" if b5p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen industrycat10_2 = substr(industrycat_isic_2, 1, 2)
+	destring industrycat10_2, replace
+	recode industrycat10_2 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	replace industrycat10_2= . if b5p17!=1
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2013_SAKERNAS/IDN_2013_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2013_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2013_SAKERNAS/IDN_2013_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2013_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1698 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2013_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2013 </_Survey Year_>
+<_Study ID_>					IDN_2013_Sakernas_v02_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			476,783 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2002 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.4 </_ISIC Version_>
+<_INDUS National_>				KBLI 2009 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2013_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO & using backcasting data]
+* Date: [2022-08-20] File: [IDN_2013_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"; change path to the intermediate file]
+* Date: [2023-01-12] File: [IDN_2013_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; educat7 added category 4; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2013_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2" & "occup_orig_2"; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2013"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sak_aug2013_backcast.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_4"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2013
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2013
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    464,490       93.82       93.82
+          1 |     17,794        3.59       97.41
+          2 |      6,279        1.27       98.68
+          3 |      2,792        0.56       99.24
+          4 |      1,400        0.28       99.52
+          5 |        882        0.18       99.70
+          6 |        567        0.11       99.82
+          7 |        336        0.07       99.88
+          8 |        198        0.04       99.92
+          9 |        180        0.04       99.96
+         10 |         44        0.01       99.97
+         11 |         36        0.01       99.98
+         12 |         52        0.01       99.99
+         13 |         28        0.01       99.99
+         14 |         15        0.00      100.00
+         16 |         17        0.00      100.00
+------------+-----------------------------------
+      Total |    495,110      100.00
+
+Because we do not know the reason for these duplicates and they only account for less than 4% of total sample, I just droppred 18,327 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates tag, gen(dup)
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = weightbc
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = b1p05
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  b1p01
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	tostring b1p02, replace
+	gen code_subnatid2 = b1p02
+	gen subnatid2 = code_subnatid2 +" - " + nkab
+	replace subnatid2 = "9499 - Tak memenuhi kecukupan sampel u/ dilakukan estimasi" if code_subnatid2=="9499"
+	replace subnatid2 = "9199 - Tak memenuhi kecukupan sampel u/ dilakukan estimasi" if code_subnatid2=="9199"
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+	preserve
+	duplicates drop subnatid2 b1p02 nkab, force
+	keep subnatid2 b1p02 nkab
+	save "`path_in_stata'\district_list_2013.dta", replace
+	restore
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = .
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = umur
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = jk
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = hub
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = hub
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = statk
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = sek
+	recode school (2 3=1) (1 4=0)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the primary school level.
+
+Original code list of variable "b5p1a" in the dataset:
+1.No schooling
+2.Incompleted primary school
+3.Primary school
+4.Package A
+5.General Junior high shool
+6.Vocational Junior High School
+7.Package B
+8.General Senior High School
+9.Vocational Senior High School
+10.Package C
+11.Diploma I/II
+12.Diploma III
+13.DIV/S1
+14.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5p1a
+	recode educat7 (4=3) (5/7=4) (8/10=5) (11/12=6) (13/14=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5p1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5p1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/10=344) (11=454) (12=550) (13=660) (14=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5p2b==1)" or
+							  "has a job but was temporarily out of work (b5p3==1)" or
+							  "employed but was temporarily out of work because of certain reasons (b5p6==5)";
+unemployed: "who do not have a job/business b5p2b!=1 & b5p3==2" & "seeking a job (b5p4==1) | (b5p5==1)"
+non-labor force:  "who do not have a job/business b5p2b!=1 & b5p3==2" & "not seeking a job (b5p4==2) & (b5p5==2)"
+
+labour force participation: 66.73%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if 0<b5p8a & b5p8a<.
+	replace lstatus = 2 if lstatus!=1 & [(b5p4==1) | (b5p5==1)]
+	replace lstatus = 3 if lstatus==.
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5p7==1 & (b5p4==2) & (b5p5==2)) or
+2)searching but not immediately available to work [(b5p4==1) | (b5p5==1)] & b5p7==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5p7==1 & (b5p4==2) & (b5p5==2)] | [(b5p4==1 | b5p5==1) & b5p7==2]
+	replace potential_lf = 0 if [b5p7==1 & (b5p4==1 | b5p5==1)] | [(b5p4==2 & b5p5==2) & (b5p7==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5p6" has 8 non-missing categories:
+	1 Discouraged
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Already have a job
+	6 Sufficient income
+	7 Unable to do work
+	8 Other, specify
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5p6
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5p21b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5p21b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5p21b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5p12 if inrange(b5p12 , 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Note that in the raw dataset, two industrial classification variables, "kbli2009_2" and "b5p18", seem to represent industry of main job and industry of the main additional job respectively. "b5p18" has 5 digits whereas "kbli2009_2" has 2 digits. Both have no labels.
+
+"b5p18" is for question No.18 asking the industry of main additional job undoubtedly, leaving "kbli2009_2" used for industry of the main job, as the values are not the same if they were both for main additional job.
+
+Moreover, most cases are that people only have kbli2009_2 while they do not have b5p18.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = kbli2009_2
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = kbli2009_2
+	replace industrycat_isic = industrycat_isic*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = industry_orig
+	recode industrycat10 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47=6) (49/53 58/63=7) (64/68 77/82=8) (84=9) (55/56 69/75 85/99=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = kji1982
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = kji1982
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/324=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if kji1982>9
+	replace occup_isco = occup_isco*100 if kji1982<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = kbji2002
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = kbji2002
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5p13a + b5p13b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5p11
+	replace whours = . if lstatus!=1
+	replace whours = . if b5p11 == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5p17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5p18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = int(b5p18/100)
+	replace industrycat_isic_2 = industrycat_isic_2*10
+	tostring industrycat_isic_2, replace format(%04.0f)
+	gen kbli2 = int(b5p18/100)
+	gen kbli4 = int(b5p18/10)
+	replace industrycat_isic_2 = "0720" if kbli2==73
+	replace industrycat_isic_2 = "4920" if kbli2==494
+	replace industrycat_isic_2 = "5520" if kbli4==5519
+	replace industrycat_isic_2 = "8550" if kbli4==8560
+	replace industrycat_isic_2 = "9600" if inlist(kbli2, 961, 962, 969)
+
+	replace industrycat_isic_2= "" if b5p17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen industrycat10_2 = substr(industrycat_isic_2, 1, 2)
+	destring industrycat10_2, replace
+	recode industrycat10_2 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	replace industrycat10_2= . if b5p17!=1
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2014_SAKERNAS/IDN_2014_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2014_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2014_SAKERNAS/IDN_2014_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2014_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1697 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2014_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					IDN_2014_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			471,525 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.4 </_ISIC Version_>
+<_INDUS National_>				KBLI 2009 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2014_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-20] File: [IDN_2014_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"]
+* Date: [2023-01-17] File: [IDN_2014_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; educat7 added category 4; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2014_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2" & "occup_orig_2"; correct a typo in the "lstatus" condition of "industrycat10"; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2014"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas14aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_4"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    459,215       93.63       93.63
+          1 |     17,264        3.52       97.15
+          2 |      6,402        1.31       98.45
+          3 |      3,380        0.69       99.14
+          4 |      1,785        0.36       99.51
+          5 |      1,014        0.21       99.71
+          6 |        595        0.12       99.83
+          7 |        312        0.06       99.90
+          8 |        207        0.04       99.94
+          9 |        130        0.03       99.97
+         10 |         55        0.01       99.98
+         11 |         24        0.00       99.98
+         12 |         52        0.01       99.99
+         13 |         14        0.00      100.00
+         18 |         19        0.00      100.00
+------------+-----------------------------------
+      Total |    490,468      100.00
+
+Because we do not know the reason for these duplicates and they only account for less than 4% of total sample, I just droppred 18,943 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates tag, gen(dup)
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = weight
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+{
+
+*<_urban_>
+	gen byte urban = klasifik
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  kode_pro
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	destring kode_kab, replace
+	tostring kode_kab, replace format(%02.0f)
+	tostring kode_pro, replace
+	gen code_subnatid2 = kode_pro+kode_kab
+	gen subnatid2 = code_subnatid2+" - " + nkab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = .
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4_k5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4_k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b4_k3
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b4_k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b4_k6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b4_k7
+	recode school (2 3=1) (1 4=0)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the primary school level.
+
+Original code list of variable "b5_r1a" in the dataset:
+1.No schooling
+2.Incompleted primary school
+3.Primary school
+4.Package A
+5.General Junior high shool
+6.Vocational Junior High School
+7.Package B
+8.General Senior High School
+9.Vocational Senior High School
+10.Package C
+11.Diploma I/II
+12.Diploma III
+13.DIV/S1
+14.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5_r1a
+	recode educat7 (4=3) (5/7=4) (8/10=5) (11/12=6) (13/14=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5_r1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5_r1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/10=344) (11=454) (12=550) (13=660) (14=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5_r2b==1)" or
+							  "has a job but was temporarily out of work (b5_r3==1)" or
+							  "employed but was temporarily out of work because of certain reasons (b5_r6==5)";
+unemployed: "who do not have a job/business b5_r2b!=1 & b5_r3==2" & "seeking a job (b5_r4==1) | (b5_r5==1)"
+non-labor force:  "who do not have a job/business b5_r2b!=1 & b5_r3==2" & "not seeking a job (b5_r4==2) & (b5_r5==2)"
+
+labour force participation: 63.49%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen lstatus = .
+	replace lstatus = 1 if b5_r2a1 == 1 | b5_r3 == 1
+    replace lstatus = 2 if missing(lstatus) & [(b5_r4==1) | (b5_r5==1)]
+    replace lstatus = 3 if missing(lstatus) & (b5_r4==2) & (b5_r5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5_r7==1 & (b5_r4==2) & (b5_r5==2)) or
+2)searching but not immediately available to work [(b5_r4==1) | (b5_r5==1)] & b5_r7==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5_r7==1 & (b5_r4==2) & (b5_r5==2)] | [(b5_r4==1 | b5_r5==1) & b5_r7==2]
+	replace potential_lf = 0 if [b5_r7==1 & (b5_r4==1 | b5_r5==1)] | [(b5_r4==2 & b5_r5==2) & (b5_r7==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5_r6" has 6 non-missing categories:
+	1 Discouraged
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Already have a job
+	6 Sufficient income
+	7 Unable to do work
+	8 Other, specify
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5_r6
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5_r21b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5_r21b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5_r21b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5_r12 if inrange(b5_r12, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Note that in the raw dataset, two industrial classification variables, "b5_r18" and "kbli2009", seem to represent industry of main job and industry of the main additional job respectively. "b5_r18" has 5 digits whereas "kbli2009" has 2 digits. Both have no labels.
+
+"b5_r18" is for question No.18 asking the industry of main additional job undoubtedly, leaving "kbli2009" used for industry of the main job, as the values are not the same if they were both for main additional job.
+
+Moreover, most cases are that people only have kbli2009_2 while they do not have b5_r18.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = kbli2009
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = kbli2009
+	replace industrycat_isic = industrycat_isic*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = kbli2009
+	recode industrycat10 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = kji1982
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = kji1982
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (153=152) (169=160) (176 177=179) (213/217=219) (323/324=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if lstatus!=.
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = kbji2002
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = kbji2002
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5_r13a + b5_r13b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5_r11
+	replace whours = . if lstatus!=1
+	replace whours = . if b5_r11 == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5_r17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5_r18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = int(b5_r18/100)
+	replace industrycat_isic_2 = industrycat_isic_2*10
+	tostring industrycat_isic_2, replace format(%04.0f)
+	gen kbli2 = int(b5_r18/100)
+	gen kbli4 = int(b5_r18/10)
+	replace industrycat_isic_2 = "0720" if kbli2==73
+	replace industrycat_isic_2 = "4920" if kbli2==494
+	replace industrycat_isic_2 = "5520" if kbli4==5519
+	replace industrycat_isic_2 = "8550" if kbli4==8560
+	replace industrycat_isic_2 = "9600" if inlist(kbli2, 961, 962, 969)
+	replace industrycat_isic_2= "" if b5_r17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen industrycat10_2 = substr(industrycat_isic_2, 1, 2)
+	destring industrycat10_2, replace
+	recode industrycat10_2 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (85/99=10) (0=.)
+	replace industrycat10_2= . if b5_r17!=1
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2015_SAKERNAS/IDN_2015_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2015_Sakernas_v01_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2015_SAKERNAS/IDN_2015_Sakernas_v01_M_v05_A_GLD/Programs/IDN_2015_Sakernas_v01_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1685 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2015_Sakernas_v01_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					IDN_2015_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			522,131 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1968 </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 1982 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.4 </_ISIC Version_>
+<_INDUS National_>				KBLI 2009 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2015_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-08-20] File: [IDN_2015_Sakernas_v01_M_v03_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"]
+* Date: [2023-01-17] File: [IDN_2015_Sakernas_v01_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2015_Sakernas_v01_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig" & "industry_orig_2" & "occup_orig_2"; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2015"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas15aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1968"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_4"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    518,535       98.58       98.58
+          1 |      6,692        1.27       99.85
+          2 |        651        0.12       99.97
+          3 |         96        0.02       99.99
+          4 |         20        0.00       99.99
+          5 |          6        0.00       99.99
+          6 |         21        0.00      100.00
+          8 |          9        0.00      100.00
+------------+-----------------------------------
+      Total |    526,030      100.00
+
+Because we do not know the reason for these duplicates and they only account for less than 1% of total sample, I just droppred 3,899 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates tag, gen(dup)
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = weight
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = klasifikas
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  kode_prov
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 65 "65 - KALIMANTAN UTARA" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	tostring kode_kab, replace format(%02.0f)
+	tostring kode_prov, replace
+	gen code_subnatid2 = kode_prov+kode_kab
+	gen subnatid2 = code_subnatid2+" - " + nama_kab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = ""
+	replace subnatid1_prev = "64 - KALIMANTAN TIMUR" if subnatid1=="65 - KALIMANTAN UTARA"
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = .
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4_k5
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4_k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b4_k3
+	recode relationharm (4 5=3) (6=4) (7=5) (8 9=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b4_k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b4_k6
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b4_k7
+	recode school (2 3=1) (1 4=0)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing.
+
+"Packet A": an educational level equavalent to the primary school level;
+"Packet B": an educational level equavalent to the junior high school level of education;
+"Packet C": an educational level equavalent to the primary school level.
+
+Original code list of variable "B5_R1A" in the dataset:
+1.No schooling
+2.Incompleted primary school
+3.Primary school
+4.Package A
+5.General Junior high shool
+6.Vocational Junior High School
+7.Package B
+8.General Senior High School
+9.Vocational Senior High School
+10.Package C
+11.Diploma I/II
+12.Diploma III
+13.DIV/S1
+14.S2/S3
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5_r1a
+	recode educat7 (4=3) (5/7=4) (8/10=5) (11/12=6) (13/14=7)
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5_r1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5_r1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/10=344) (11=454) (12=550) (13=660) (14=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+/*<_lstatus_note_>
+
+We define the employed as who "worked primarily (b5_r2a1==1)" or
+							  "has a job but was temporarily out of work (b5_r3==1)";
+unemployed: "who do not have a job/business mi(lstatus)" & "seeking a job (b5_r4==1) | (b5_r5==1)"
+non-labor force:  "who do not have a job/business mi(lstatus)" & "not seeking a job (b5_r4==2) & (b5_r5==2)"
+
+Labour force participation: 66.57%
+
+<_lstatus_note_>*/
+
+
+*<_lstatus_>
+	gen lstatus = .
+	replace lstatus = 1 if b5_r2a1 == 1 | b5_r3 == 1
+    replace lstatus = 2 if missing(lstatus) & [(b5_r4==1) | (b5_r5==1)]
+    replace lstatus = 3 if missing(lstatus) & (b5_r4==2) & (b5_r5==2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5_r7==1 & (b5_r4==2) & (b5_r5==2)) or
+2)searching but not immediately available to work [(b5_r4==1) | (b5_r5==1)] & b5_r7==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5_r7==1 & (b5_r4==2) & (b5_r5==2)] | [(b5_r4==1 | b5_r5==1) & b5_r7==2]
+	replace potential_lf = 0 if [b5_r7==1 & (b5_r4==1 | b5_r5==1)] | [(b5_r4==2 & b5_r5==2) & (b5_r7==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5_r6" has 8 non-missing categories:
+	1 Discouraged
+	2 Have a job but not yet starting it
+	3 Attending school
+	4 Housekeeping
+	5 Already have a job
+	6 Sufficient income
+	7 Unable to do work
+	8 Other, specify
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5_r6
+	recode nlfreason (3=1) (4=2) (7=4) (1 2 5 6 8=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5_r21b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5_r21b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5_r21b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5_r12 if inrange(b5_r12, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Note that in the raw dataset, two industrial classification variables, "b5_r18" and "kbli2009_2", seem to represent industry of main job and industry of the main additional job respectively. "b5_r18" has 5 digits whereas "kbli2009_2" has 2 digits. Both have no labels.
+
+"b5_r18" is for question No.18 asking the industry of main additional job undoubtedly, leaving "kbli2009_2" used for industry of the main job, as the values are not the same if they were both for main additional job.
+
+Moreover, most cases are that people only have kbli2009_2 while they do not have b5_r18.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = kbli2009_2
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = kbli2009_2
+	replace industrycat_isic = industrycat_isic*100
+	tostring industrycat_isic, replace format(%04.0f)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = kbli2009_2
+	recode industrycat10 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (0 85/99=10)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = kji1982
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = kji1982
+	recode occup_isco (55=5) (123=129) (133=132) (134=133) (135=134) (136=139) (137=135) (142/145=141) (152 153=159) (169=160) (176 177=179) (213/217=219) (323/324=320) (332/333=339) (349=340) (352 353=359) (354 355=352) (371 372=370) (442/443=441) (444=442) (445=443) (593=599) (613=610) (632=630) (633=632) (642/646=641) (721/729=720) (739=730) (757=759) (911=910) (932=939) (944/946=949) (987=989)
+	replace occup_isco = occup_isco*10 if kji1982>9
+	replace occup_isco = occup_isco*100 if kji1982<10
+	tostring occup_isco, replace format(%04.0f)
+	replace occup_isco = "" if lstatus!=1
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = kbji2002
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = kbji2002
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 13 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5_r13a + b5_r13b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5_r11
+	replace whours = . if lstatus!=1
+	replace whours = . if b5_r11 == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+/*<_empstat_2_note_>
+
+We do not have information on the employment status of the main additional job. But we know whether the respondent has a second job. Therefore, for people who have a second job, they were all coded as "Other, unclassified workers."
+
+<_empstat_2_note_>*/
+
+
+*<_empstat_2_>
+	gen byte empstat_2 = 5 if b5_r17==1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5_r18
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = int(b5_r18/100)
+	replace industrycat_isic_2 = industrycat_isic_2*10
+	tostring industrycat_isic_2, replace format(%04.0f)
+	gen kbli2 = int(b5_r18/100)
+	gen kbli4 = int(b5_r18/10)
+	replace industrycat_isic_2 = "0720" if kbli2==73
+	replace industrycat_isic_2 = "4920" if kbli2==494
+	replace industrycat_isic_2 = "5520" if kbli4==5519
+	replace industrycat_isic_2 = "8550" if kbli4==8560
+	replace industrycat_isic_2 = "9600" if inlist(kbli2, 961, 962, 969)
+	replace industrycat_isic_2= "" if b5_r17!=1
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen industrycat10_2 = substr(industrycat_isic_2, 1, 2)
+	destring industrycat10_2, replace
+	recode industrycat10_2 (1/3=1) (5/9=2) (10/33=3) (35/39=4) (41/43=5) (45/47 55/56=6) (49/53 58/63=7) (64/82=8) (84=9) (0 85/99=10)
+	replace industrycat10_2 = . if b5_r17!=1
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2016_SAKERNAS/IDN_2016_Sakernas_v01_M_v06_A_GLD/Programs/IDN_2016_Sakernas_v01_M_v06_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2016_SAKERNAS/IDN_2016_Sakernas_v01_M_v06_A_GLD/Programs/IDN_2016_Sakernas_v01_M_v06_A_GLD_ALL.do
@@ -1,0 +1,1707 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2016_Sakernas_v01_M_v06_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					IDN_2016_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			131,152 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2014 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 2015 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2016_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-07-13] File: [IDN_2016_Sakernas_v01_M_v03_A_GLD.do] - [Adding educat4-educat7]
+* Date: [2022-08-20] File: [IDN_2016_Sakernas_v01_M_v04_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"]
+* Date: [2023-01-12] File: [IDN_2016_Sakernas_v01_M_v05_A_GLD.do] - [Change directories; fix "primary school completed" of educat7; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2016_Sakernas_v01_M_v06_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2016"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v06"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas16aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    131,152      100.00      100.00
+------------+-----------------------------------
+      Total |    131,152      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = urutan
+	format pid %06.0f
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_note_>
+
+The original weight variable is called "weight".
+
+<_weight_note_>*/
+
+
+*<_weight_>
+	*gen weight = weight
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = klasifikas
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  kode_prov
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 65 "65 - KALIMANTAN UTARA" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = .
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2_r1
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4_k6
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4_k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b4_k3
+	recode relationharm (4 5=3) (6=4) (7/9 0=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b4_k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b4_k7
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = b5_r4a
+	recode eye_dsablty (3=4)
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = b5_r4b
+	recode hear_dsablty (4=1) (5=2) (6=4)
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = b5_r4c
+	recode walk_dsablty (3=4)
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = b5_r4e
+	recode comm_dsablty (3=4)
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 10
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b4_k8
+	recode school (2=1) (1 3=0)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing and so were educat7, educat5,
+and educat4.
+
+There is no such category as "No education" nor missing observations. So
+probably the survey grouped "no education" into "not yet completed primary school".
+
+Original code list of variable "b5_r1a" in the dataset:
+1.No elementary (SD) diploma
+2.Equivalency Package A
+3.Special elementary (SDLB)
+4.Elementary (SD/MI)
+5.Equivalency Package B
+6.Special junior high (SMPLB)
+7.Junior high (SMP/MTs)
+8.Package C
+9.Special senior high (SMALB)
+10.Senior high (SMA/MA)
+11.Vocational high (SMK/MAK)
+12.Non-degree diploma I/II
+13.Diploma III
+14.Diploma IV/Bachelor’s degree (S1)
+15.Master Degree (S2)
+16.Doctoral Degree (S3)
+
+1.Not yet completed primary
+2.Package A
+3.Primary for disabled
+4.Primary
+5.Package B
+6.Special junior high (SMPLB)
+7.Junior high (SMP/MTs)
+8.Package C
+9.Special senior high (SMALB)
+10.Senior high (SMA/MA)
+11.Vocational high (SMK/MAK)
+12.Non-degree diploma I/II
+13.Diploma III
+14.Diploma IV/Bachelor’s degree (S1)
+15.Master Degree (S2)
+16.Doctoral Degree (S3)
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5_r1a
+	recode educat7 (1=2) (2/4=3) (5/7=4) (8/11=5) (12/13=6) (14/16=7)
+	replace educat7 = 1 if b4_k8==1
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	recode educat4 (3=2) (4=3) (5=4)
+	replace educat4 = . if age < ed_mod_age & age!=.
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5_r1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5_r1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/11=344) (12=454) (13=550) (14=660) (15=760) (16=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 10
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b5_r31 != .
+    replace lstatus = 2 if (b5_r11==1 | b5_r12==1 | b5_r16a==1 | b5_r16a==2) & b5_r17a==1 & missing(lstatus)
+    replace lstatus = 3 if missing(lstatus)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5_r17b==1 & (b5_r11==2) & (b5_r12==2)) or
+2)searching but not immediately available to work ((b5_r11==1) | (b5_r12==1)) & (b5_r17a==2 | b5_r17b==2)
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5_r17b==1 & (b5_r11==2) & (b5_r12==2)] | [((b5_r11==1) | (b5_r12==1)) & (b5_r17a==2 | b5_r17b==2)]
+	replace potential_lf = 0 if [b5_r17b==1 & (b5_r11==1 | b5_r12==1)] | [(b5_r17a==2 | b5_r17b==2) & (b5_r11==2) & (b5_r12==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5_r16a" has 12 non-missing categories:
+	1  Already accepted for work but not yet starting the job
+	2  Already having a business but not yet starting it
+	3  Hopeless; feeling impossible to get a job
+	4  Already having a job/business
+	5  Feeling good enough already/having other income sources (pension, inheritance, etc.)
+	6  Taking care of household
+	7  Attending school/just completed school/will continue school
+	8  Pregnancy/childbirth/postnatal care
+	9  Lack of infrastructure (assets, roads, transport, employment service)
+	10 Experiencing social exclusion/rejection
+	11 Inability to work
+	12 Other, specify
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5_r21b
+	recode nlfreason (7=1) (6=2) (11=4) (1/5 8/10 12=5)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5_r21b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_note_>
+	gen byte unempldur_l = b5_r21b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_note_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5_r21b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5_r23 if inrange(b5_r23, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+/*<_ocusec_note_>
+
+The original variable "b5_r31" has 5 categories:
+
+1. Government
+2. international institution/organization
+3. non-profit institutions
+4. profit institutions (private enterprises, state-owned enterprises, regional-owned enterprises)
+5. cooperatives
+6. individual/ household business
+7. Houeshold
+8. Others, specify:
+9. Do not know
+
+<_ocusec_note_>*/
+
+*<_ocusec_>
+	gen byte ocusec = b5_r31
+	recode ocusec (2 8 9=4) (3 4/7=2)
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_>
+
+Variable "b5_r19_17" uses KBLI 2015, including 17 sectors, which is at one-digit level.
+Note that in the raw dataset variable "b5_r19_17" does not have labels.
+
+<_industry_orig_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b5_r19_17
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b5_r19_17
+	recode industrycat10 (5=4) (6=5) (7 9=6) (8 10=7) (11 12 13=8) (14=9) (15 16 17=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+/*<_occup_orig_note_>
+
+Variable "b5_r20_201" uses KBJI 2014 and it has one digit and 10 categories in total.
+Note that in the raw dataset variable "b5_r20_201" does not have labels.
+
+<_occup_orig_note_>*/
+
+
+*<_occup_orig_>
+	gen occup_orig = b5_r20_201
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = b5_r20_201
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = b5_r20_201
+	replace occup = . if lstatus!=1
+	replace occup = . if occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 26 devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5_r26a + b5_r26b
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5_r22b
+	replace whours = . if lstatus!=1
+	replace whours = . if b5_r22b == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is "wage_no_compen". But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+/*<_contract_note_>
+
+We counted  "Verbal agreement" as "having a contract" as well, considering its big magnitude larger than category 1 "employment agreement for unspecified time".
+
+<_contract_note_>*/
+
+
+*<_contract_>
+	gen byte contract = b5_r29
+	recode contract (2/3=1) (4=0) (5=.)
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = b5_r28a
+	recode healthins (0 3=.) (2=0)
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old-age insurance" and "pension insurance" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = 1 if b5_r28c == 1 | b5_r28d == 1
+	replace socialsec = 0 if b5_r28c == 2 & b5_r28d == 5
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = b5_r30
+	recode union (3=.) (2=0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = b5_r36
+	recode empstat_2 (1 2=4) (4/6=1) (7=2)
+	replace empstat_2=. if b5_r34!=1
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5_r35_17
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = b5_r37b-b5_r22b
+	replace whours_2 = . if b5_r34!=1
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2017_SAKERNAS/IDN_2017_Sakernas_v01_M_v07_A_GLD/Programs/IDN_2017_Sakernas_v01_M_v07_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2017_SAKERNAS/IDN_2017_Sakernas_v01_M_v07_A_GLD/Programs/IDN_2017_Sakernas_v01_M_v07_A_GLD_ALL.do
@@ -1,0 +1,1695 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2017_Sakernas_v01_M_v07_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					IDN_2017_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			536,809 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2014 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 2015 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2017_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-07-13] File: [IDN_2017_Sakernas_v01_M_v03_A_GLD.do] - [Adding educat4-educat7]
+* Date: [2022-08-20] File: [IDN_2017_Sakernas_v01_M_v04_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"]
+* Date: [2022-11-08] File: [IDN_2017_Sakernas_v01_M_v05_A_GLD.do] - [Recode "lstatus"and "potential_lf".]
+* Date: [2023-01-12] File: [IDN_2017_Sakernas_v01_M_v06_A_GLD.do] - [Change directories; recoded educat4 and educat5; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2017_Sakernas_v01_M_v07_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2017"
+local survey  "SAKERNAS"
+local vermast "v01"
+local veralt  "v07"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas17aug.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    536,648       99.94       99.94
+          1 |        322        0.06      100.00
+------------+-----------------------------------
+      Total |    536,970      100.00
+
+We do not know the reason for the duplicates. Because they only take 0.06% of all observations, I just dropped 161 observations.
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	duplicates tag, gen(dup)
+	duplicates drop
+	gen pid = string(_n,"%06.0f")
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+/*<_weight_>
+
+The original weight variable is called "weight".
+
+<_weight_>*/
+
+
+*<_weight_>
+	*gen weight = weight
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = klasifikas
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  kode_prov
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 65 "65 - KALIMANTAN UTARA" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	tostring kode_kab, replace format(%02.0f)
+	tostring kode_prov, replace
+	gen code_subnatid2 = kode_prov+kode_kab
+	gen subnatid2 = code_subnatid2+" - " + nama_kab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2_r1
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4_k6
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4_k4
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b4_k3
+	recode relationharm (4 5=3) (6=4) (7/9 0=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b4_k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b4_k8
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = b5_r4a
+	recode eye_dsablty (3=4)
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = b5_r4b
+	recode hear_dsablty (4=1) (5=2) (6=4)
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = b5_r4c
+	recode walk_dsablty (3=4)
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = b5_r4e
+	recode comm_dsablty (3=4)
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 5
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b4_k7
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing and so were educat7, educat5,
+and educat4.
+
+In 2019, there is no such category as "No education" nor missing observations. So
+probably the survey grouped "no education" into "not yet completed primary school".
+
+Original code list of variable "b5_r1a" in the dataset:
+1.Not yet completed primary
+2.Package A
+3.Primary for disabled
+4.Primary
+5.Package B
+6.Special junior high (SMPLB)
+7.Junior high (SMP/MTs)
+8.Package C
+9.Special senior high (SMALB)
+10.Senior high (SMA/MA)
+11.Vocational high (SMK/MAK)
+12.Non-degree diploma I/II
+13.Diploma III
+14.Diploma IV/Bachelor’s degree (S1)
+15.Master Degree (S2)
+16.Doctoral Degree (S3)
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5_r1a
+	recode educat7 (1=2) (2/4=3) (5/7=4) (8/11=5) (12/13=6) (14/16=7)
+	replace educat7 = 1 if b4_k7==1
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	recode educat4 (3=2) (4=3) (5=4)
+	replace educat4 = . if age < ed_mod_age & age!=.
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5_r1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5_r1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/11=344) (12=454) (13=550) (14=660) (15=760) (16=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 5
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen lstatus = .
+	replace lstatus = 1 if b5_r35 != 0
+    replace lstatus = 2 if ( b5_r15a==1 | b5_r15b==1 ) & b5_r21b==1 & missing(lstatus)
+    replace lstatus = 3 if missing(lstatus)
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5_r21b==1 & (b5_r15a==2) & (b5_r15b==2)) or
+2)searching but not immediately available to work ((b5_r15a==1) | (b5_r15b==1)) & b5_r21b==2
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5_r21b==1 & (b5_r15a==2) & (b5_r15b==2)] | [((b5_r15a==1) | (b5_r15b==1)) & b5_r21b==2]
+	replace potential_lf = 0 if [b5_r21b==1 & (b5_r15a==1 | b5_r15b==1)] | [b5_r21b==2 & (b5_r15a==2) & (b5_r15b==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5_r20a" has 13 non-missing categories:
+	1  Already accepted for work but not yet starting the job
+	2  Already having a business but not yet starting it
+	3  Hopeless; feeling impossible to get a job
+	4  Already having a job/business
+	5  Feeling good enough already/having other income sources (pension, inheritance, etc.)
+	6  Taking care of household
+	7  Attending school/just completed school/will continue school
+	8  Pregnancy/childbirth/postnatal care
+	9  Lack of infrastructure (assets, roads, transport, employment service)
+	10 Experiencing social exclusion/rejection
+	11 Under-age
+	12 Inability to work
+	13 Other, specify 1-12
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5_r20a
+	recode nlfreason (7=1) (6=2) (12=4) (1/5 8/11 13=5) (0=.)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5_r25b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5_r25b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5_r25b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5_r27a if inrange(b5_r27a, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5) 
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+/*<_ocusec_note_>
+
+The original variable "b5_r35" has 5 categories:
+
+1. Government/international institution/profit organization/non profit/cooperative
+2. Individual/household business
+3. Houeshold
+4. Others, specify:
+5. Do not know
+
+But in the raw dataset, not only there is an extra cateogry of zero (which is supposed to be missing), there is another category "6". Because the variable does not have label, we do not know what exactly those categories represent. As such, I group 1,4 5 and 6 into "ocusec-4"; 2 and 3 into "ocusec-2".
+
+	gen byte ocusec = b5_r35
+	recode ocusec (1 4 5 6=4) (3=2) (0=.)
+
+<_ocusec_note_>*/
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Variable "b5_r23_17" uses KBLI 2015, including 17 sectors which is at 1-digit level.
+Note that in the raw dataset variable "b5_r23" does not have labels.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b5_r23_17
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = ""
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b5_r23_17
+	recode industrycat10 (5=4) (6=5) (7 9=6) (8 10=7) (11 12 13=8) (14=9) (15 16 17=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+/*<_occup_orig_note_>
+
+Variable "b5_r24_kbj" uses KBJI 2014 and it has one digit and 10 categories in total.
+Note that in the raw dataset variable "b5_r24_kbj" does not have labels.
+
+<_occup_orig_note_>*/
+
+
+*<_occup_orig_>
+	gen occup_orig = b5_r24_201
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = b5_r24_201
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = b5_r24_201
+	replace occup = . if lstatus!=1
+	replace occup = . if  occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 30 has 3 parts aksing about workdays and monthly salary of 1) self-employed people and 2) employees. Variable "b5_r30a" is for self-employed people whereas "b5_r30b" is for employees.
+
+Each of these two variables devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary. Part b is about "net income"; part c has 2 sub-sections asking about "salary/allowance" and "transportation and food allowance". "Transport and meal allowance" was not included for "wage_no_compen".
+
+	count if (b5_r30b1!=0 | b5_r30b2!=0 ) & (b5_r30c11!=0 | b5_r30c12!=0)
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = b5_r30b1 + b5_r30b2 + b5_r30c11 + b5_r30c12
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = b5_r26a
+	replace whours = . if lstatus!=1
+	replace whours = . if b5_r26a == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is wage_no_compen. But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+/*<_contract_note_>
+
+We counted  "Verbal agreement" as "having a contract" as well, considering its big magnitude larger than category 1 "employment agreement for unspecified time".
+
+<_contract_note_>*/
+
+
+*<_contract_>
+	gen byte contract = b5_r33
+	recode contract (2/3=1) (4=0) (5 0=.)
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = b5_r32a
+	recode healthins (0 3=.) (2=0)
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old age benefit (lump sum)" and "pension benefit (annuity)" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = 1 if b5_r32d == 4 | b5_r32e == 1
+	replace socialsec = 0 if b5_r32d == 5 & b5_r32e == 2
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = b5_r34
+	recode union (0 3=.) (2=0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b5_r27b
+	recode firmsize_l (2=5) (3=20) (4=100) (0=.)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b5_r27b
+	recode firmsize_u (1=4) (2=19) (3=99) (0=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = b5_r42
+	recode empstat_2 (1 2=4) (4/6=1) (7=2) (0=.)
+	replace empstat_2=. if b5_r38b==2
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5_r39_17
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = b5_r40_201
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = b5_r41
+	replace whours_2 = . if b5_r38a==2 & b5_r38b == 2
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2018_SAKERNAS/IDN_2018_Sakernas_v02_M_v05_A_GLD/Programs/IDN_2018_Sakernas_v02_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2018_SAKERNAS/IDN_2018_Sakernas_v02_M_v05_A_GLD/Programs/IDN_2018_Sakernas_v02_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1709 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2018_Sakernas_v02_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-18 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					IDN_2018_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			508,460 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2014 </_OCCUP National_>
+<_ISIC Version_>				ISIC Rev.4 </_ISIC Version_>
+<_INDUS National_>				KBLI 2015 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2018_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-07-13] File: [IDN_2018_Sakernas_v01_M_v03_A_GLD.do] - [Adding educat4-educat7]
+* Date: [2022-07-21] File: [IDN_2018_Sakernas_v02_M_v01_A_GLD.do] - [Master dataset switched to backcasted SAKERNAS 2018 August]
+* Date: [2022-08-20] File: [IDN_2018_Sakernas_v02_M_v02_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"]
+* Date: [2022-11-08] File: [IDN_2018_Sakernas_v02_M_v03_A_GLD.do] - [Recode "lstatus"and "potential_lf".]
+* Date: [2023-01-12] File: [IDN_2018_Sakernas_v02_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"; recoded whours (used to be work days)]
+* Date: [2023-03-12] File: [IDN_2018_Sakernas_v02_M_v05_A_GLD.do] - [Recode "industry_orig" & "occup_orig"; change "Z" drive to "Y" drive]
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2018"
+local survey  "SAKERNAS"
+local vermast "v02"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas18aug_backcasting.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_4"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    508,460      100.00      100.00
+------------+-----------------------------------
+      Total |    508,460      100.00
+
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = urutan
+	format pid %06.0f
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = final_weig
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = klasifikas
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  kode_prov
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 65 "65 - KALIMANTAN UTARA" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	tostring kode_kab, replace format(%02.0f)
+	tostring kode_prov, replace
+	gen code_subnatid2 = kode_prov+kode_kab
+	gen subnatid2 = code_subnatid2+" - " + nama_kab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2_r1
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4_k8
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4_k6
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b4_k3
+	recode relationharm (3 4 5 6=3) (7=4) (8=5) (9 10 11=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b4_k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b4_k10
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = b5_r4a
+	recode eye_dsablty (3=4)
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = b5_r4b
+	recode hear_dsablty (4=1) (5=2) (6=4)
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = b5_r4c
+	recode walk_dsablty (3=4)
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = b5_r4e
+	recode comm_dsablty (3=4)
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 5
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b4_k9
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing and so were educat7, educat5,
+and educat4.
+
+In 2019, there is no such category as "No education" nor missing observations. So
+probably the survey grouped "no education" into "not yet completed primary school".
+
+Original code list of variable "b5_r1a" in the dataset:
+1.No elementary (SD) diploma
+2.Equivalency Package A
+3.Special elementary (SDLB)
+4.Elementary (SD/MI)
+5.Equivalency Package B
+6.Special junior high (SMPLB)
+7.Junior high (SMP/MTs)
+8.Package C
+9.Special senior high (SMALB)
+10.Senior high (SMA/MA)
+11.Vocational high (SMK/MAK)
+12.Non-degree diploma I/II
+13.Diploma III
+14.Diploma IV/Bachelor’s degree (S1)
+15.Master Degree (S2)
+16.Doctoral Degree (S3)
+
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5_r1a
+	recode educat7 (1=2) (2/4=3) (5/7=4) (8/11=5) (12/13=6) (14/16=7)
+	replace educat7 = 1 if b4_k9==1
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5	
+	recode educat4 (3=2) (4=3) (5=4)
+	replace educat4 = . if age < ed_mod_age & age!=.
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5_r1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5_r1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/11=344) (12=454) (13=550) (14=660) (15=760) (16=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v = "ISCED-2011"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 5
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b5_r37 != 0
+    replace lstatus = 2 if (b5_r15a==1 | b5_r15b==1 ) & b5_r21b==1 & missing(lstatus)
+    replace lstatus = 3 if missing(lstatus)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5_r21b==1 & (b5_r15a==2) & (b5_r15b==2)) or
+2)searching but not immediately available to work ((b5_r15a==1) | (b5_r15b==1)) & b5_r21b==2
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [b5_r21b==1 & (b5_r15a==2) & (b5_r15b==2)] | [((b5_r15a==1) | (b5_r15b==1)) & b5_r21b==2]
+	replace potential_lf = 0 if [b5_r21b==1 & (b5_r15a==1 | b5_r15b==1)] | [b5_r21b==2 & (b5_r15a==2) & (b5_r15b==2)]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "b5_r20a" has 14 non-missing categories:
+	1  Already accepted for work but not yet starting the job
+	2  Already having a business but not yet starting it
+	3  Hopeless; feeling impossible to get a job
+	4  Already having a job/business
+	5  Feeling good enough already/having other income sources (pension, inheritance, etc.)
+	6  Taking care of household
+	7  Attending school/just completed school/will continue school
+	8  Pregnancy/childbirth/postnatal care
+	9  Lack of infrastructure (assets, roads, transport, employment service)
+	10 Absence/shortage of capital
+	11 Under-age
+	12 Advanced age
+	13 Inability to work
+	14 Unable to be classified into code 1-13
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5_r20a
+	recode nlfreason (7=1) (6=2) (12=3) (13=4) (1/5 8/11 14=5) (0=.)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5_r25b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5_r25b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5_r25b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5_r27a if inrange(b5_r27a, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = b5_r37
+	recode ocusec (2 8 9=4) (3/7=2) (0=.)
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Variable "b5_r23" uses KBLI 2015 which has five digits originally.
+Note that in the raw dataset variable "b5_r23" does not have labels.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b5_r23
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+/*<_industrycat_isic_note_>
+
+we used the first three digits of variable "b5_r23" to do industrial mappings.
+Only 6 categories need rematching manually. All the others can be mapped to ISIC
+directly.
+
+<_industrycat_isic_note_>*/
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = int(b5_r23/100)
+	replace industrycat_isic = industrycat_isic*10
+	tostring industrycat_isic, replace format(%04.0f)
+	gen kbli2 = int(b5_r23/100)
+	gen kbli4 = int(b5_r23/10)
+	replace industrycat_isic = "0720" if kbli2==73
+	replace industrycat_isic = "4920" if kbli2==494
+	replace industrycat_isic = "5520" if kbli4==5519
+	replace industrycat_isic = "8550" if kbli4==8560
+	replace industrycat_isic = "9600" if inlist(kbli2, 961, 962, 969)
+	replace industrycat_isic = "" if lstatus!=1
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b5_r23_sek
+	recode industrycat10 (5=4) (6=5) (7 9=6) (8 10=7) (11 12 13=8) (14=9) (15 16 17=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+/*<_occup_orig_>
+
+Variable "b5_r24_kbj" uses KBJI 2014 and it has one digit and 10 categories in total.
+Note that in the raw dataset variable "b5_r24_kbj" does not have labels.
+
+<_occup_orig_>*/
+
+
+*<_occup_orig_>
+	gen occup_orig = b5_r24_kbj
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = b5_r24_kbj
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = b5_r24_kbj
+	replace occup = . if lstatus!=1
+	replace occup = . if  occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 31 has 3 parts aksing about working days and monthly salary of 1) self-employed people and 2) employees. Variable "b5_r31b" is for self-employed people whereas "b5_r31c" is for employees.
+
+Each of these two variables devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+	count if (b5_r31b1!=0 | b5_r31b2!=0 ) & (b5_r31c1!=0 | b5_r31c2!=0)
+
+17 observations in total answered both "b5_r31b" and "b5_r31c", indicating that they self-employed and employees at the same time. But all of these observations have the same amount of income (in cash) from the self-employed work and being an employee, which is suspicious. Therefore, I treated these observations as "wrongly" answered the questions and did not add up across "b5_r31b" and  "b5_r31c".
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	
+	gen wageb = b5_r31b1+b5_r31b2
+	gen wagec = b5_r31c1+b5_r31c2
+	gen double wage_no_compen = .
+	replace wage_no_compen = wageb if wageb==wagec
+	replace wage_no_compen = wageb if wageb>0 & wagec==0
+	replace wage_no_compen = wagec if wageb==0 & wagec>0
+	replace wage_no_compen = . if lstatus!=1
+	replace wage_no_compen = . if empstat==2
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours= b5_r26a8
+	replace whours = . if lstatus!=1
+	replace whours = . if b5_r26a8==0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is wage_no_compen. But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+/*<_contract_note_>
+
+We counted  "Verbal agreement" as "having a contract" as well, considering its big magnitude larger than category 1 "employment agreement for unspecified time".
+
+<_contract_note_>*/
+
+
+
+*<_contract_>
+	gen byte contract = b5_r34
+	recode contract (2/3=1) (4=0) (5 0=.)
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = b5_r33a
+	recode healthins (0 3=.) (2=0)
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old age benefit (lump sum)" and "pension benefit (annuity)" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = 1 if b5_r33d == 4 | b5_r33e == 1
+	replace socialsec = 0 if b5_r33d == 5 & b5_r33e == 2
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = b5_r35
+	recode union (0 3=.) (2=0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+/*<_firmsize_l_note_>
+
+This question was only asked to those who are seld-employed.
+
+<_firmsize_l_note_>*/
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b5_r27b
+	recode firmsize_l (2=5) (3=20) (4=100) (0=.)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b5_r27b
+	recode firmsize_u (1=4) (2=19) (3=99) (0=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = b5_r44
+	recode empstat_2 (1 2=4) (4/6=1) (6=5) (7=2) (0=5)
+	replace empstat_2 = . if b5_r40a==2 & b5_r40b == 2
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5_r41_sek
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = b5_r42_kbj
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = .
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = b5_r43
+	replace whours_2 = . if b5_r40a==2 & b5_r40b == 2
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = ""
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = ""
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/IDN/IDN_2019_SAKERNAS/IDN_2019_Sakernas_v02_M_v05_A_GLD/Programs/IDN_2019_Sakernas_v02_M_v05_A_GLD_ALL.do
+++ b/GLD/IDN/IDN_2019_SAKERNAS/IDN_2019_Sakernas_v02_M_v05_A_GLD/Programs/IDN_2019_Sakernas_v02_M_v05_A_GLD_ALL.do
@@ -1,0 +1,1696 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+================================================================================================*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				IDN_2019_Sakernas_v02_M_v05_A_GLD.do </_Program name_>
+<_Application_>					Stata MP 16.1 <_Application_>
+<_Author(s)_>					Wolrd Bank Job's Group </_Author(s)_>
+<_Date created_>				2021-08-23 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Indonesia (IDN) </_Country_>
+<_Survey Title_>				Survei Angkatan Kerja Nasional (The National Labor Force Survey) </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					IDN_2019_Sakernas_v01_M </_Study ID_>
+<_Data collection from (M/Y)_>	[MM/YYYY] </_Data collection from (M/Y)_>
+<_Data collection to (M/Y)_>	[MM/YYYY] </_Data collection to (M/Y)_>
+<_Source of dataset_> 			Shared with Job's Group by the World Bank Indonesia Team
+								data request form required to get the access</_Source of dataset_>
+<_Sample size (HH)_> 			N/A </_Sample size (HH)_>
+<_Sample size (IND)_> 			782,789 </_Sample size (IND)_>
+<_Sampling method_> 			Two-stage cluster sampling method </_Sampling method_>
+<_Geographic coverage_> 		Province & District </_Geographic coverage_>
+<_Currency_> 					Indonesian Rupiah </_Currency_>
+---------------------------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED-2011 </_ISCED Version_>
+<_ISCO Version_>				N/A </_ISCO Ver UP National_>
+<_OCCUP National_>				KBJI 2014 </_OCCUP National_>
+<_ISIC Version_>				N/A </_ISIC Version_>
+<_INDUS National_>				KBLI 2015 </_INDUS National_>
+---------------------------------------------------------------------------------------
+
+<_Version Control_>
+
+* Date: [2022-05-24] File: [IDN_2019_Sakernas_v01_M_v02_A_GLD.do] - [Reducing original indutry and occupation codes digits and remapping those two to ISIC/ISCO.]
+* Date: [2022-07-13] File: [IDN_2019_Sakernas_v01_M_v03_A_GLD.do] - [Adding educat4-educat7]
+* Date: [2022-07-21] File: [IDN_2019_Sakernas_v02_M_v01_A_GLD.do] - [Master dataset switched to backcasted SAKERNAS 2019 August]
+* Date: [2022-08-20] File: [IDN_2019_Sakernas_v02_M_v02_A_GLD.do] - [Recode employment status:Agricultural & non-agricultual casual worker recoded to "paid employee"]
+* Date: [2022-11-08] File: [IDN_2019_Sakernas_v02_M_v03_A_GLD.do] - [Recode "lstatus"and "potential_lf".]
+* Date: [2023-01-12] File: [IDN_2019_Sakernas_v02_M_v04_A_GLD.do] - [Change directories; Empstat "self-employed" assisted with non-paid workers were "self-employed"]
+* Date: [2023-03-12] File: [IDN_2019_Sakernas_v02_M_v05_A_GLD.do] - [Recode "industry_orig" and "occup_orig"; change "Z" drive to "Y" drive]
+
+</_Version Control_>
+
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+================================================================================================*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+* Define path sections
+local server  "Y:\GLD-Harmonization\573465_JT"
+local country "IDN"
+local year    "2019"
+local survey  "SAKERNAS"
+local vermast "v02"
+local veralt  "v05"
+
+* From the definitions, set path chunks
+local level_1      "`country'_`year'_`survey'"
+local level_2_mast "`level_1'_`vermast'_M"
+local level_2_harm "`level_1'_`vermast'_M_`veralt'_A_GLD"
+
+* From chunks, define path_in, path_output folder
+local path_in_stata "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Stata"
+local path_in_other "`server'\\`country'\\`level_1'\\`level_2_mast'\Data\Original"
+local path_output   "`server'\\`country'\\`level_1'\\`level_2_harm'\Data\Harmonized"
+* Define Output file name
+local out_file "`level_2_harm'_ALL.dta"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "`path_in_stata'\sakernas19aug_backcasting.dta", clear
+
+/*%%=============================================================================================
+	2: Survey & ID
+================================================================================================*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "IDN"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "Sakernas"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "Survei Angkatan Kerja Nasional"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = ""
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = ""
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "`vermast'"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "`veralt'"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year = 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+	gen hhid = .
+	label var hhid "Household id"
+*</_hhid_>
+
+
+/*<_pid_note_>
+
+	duplicates tag, gen(dup)
+	tab dup
+
+        dup |      Freq.     Percent        Cum.
+------------+-----------------------------------
+          0 |    782,789      100.00      100.00
+------------+-----------------------------------
+      Total |    782,789      100.00
+
+<_pid_note_>*/
+
+
+*<_pid_>
+	gen pid = urutan
+	format pid %06.0f
+	tostring pid, replace
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	gen weight = final_weig
+	label var weight "Survey sampling weight"
+*</_weight_>
+
+
+/*<_psu_note_>
+
+We do know that the primary sampling unit of Sakernas is census block and the
+census block number is in the questionnaire. However this information is not
+provided due to it is part of the confidential information withheld by the NSO.
+
+<_psu_note_>*/
+
+
+*<_psu_>
+	gen psu = .
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = .
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = .
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = .
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+================================================================================================*/
+
+{
+
+*<_urban_>
+	gen byte urban = klasifikas
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+	gen byte subnatid1_copy =  kode_prov
+	label de lblsubnatid1 11 "11 - ACEH" 12 "12 - SUMATERA UTARA" 13 "13 - SUMATERA BARAT" 14 "14 - RIAU" 15 "15 - JAMBI" 16 "16 - SUMATERA SELATAN" 17 "17 - BENGKULU" 18 "18 - LAMPUNG" 19 "19 - KEPULAUAN BANGKA BELITUNG" 21 "21 - KEPULAUAN RIAU" 31 "31 - DKI JAKARTA" 32 "32 - JAWA BARAT" 33 "33 - JAWA TENGAH" 34 "34 - DI YOGYAKARTA" 35 "35 - JAWA TIMUR" 36 "36 - BANTEN" 51 "51 - BALI" 52 "52 - NUSA TENGGARA BARAT" 53 "53 - NUSA TENGGARA TIMUR" 61 "61 - KALIMANTAN BARAT" 62 "62 - KALIMANTAN TENGAH" 63 "63 - KALIMANTAN SELATAN" 64 "64 - KALIMANTAN TIMUR" 65 "65 - KALIMANTAN UTARA" 71 "71 - SULAWESI UTARA" 72 "72 - SULAWESI TENGAH" 73 "73 - SULAWESI SELATAN" 74 "74 - SULAWESI TENGGARA" 75 "75 - GORONTALO" 76 "76 - SULAWESI BARAT" 81 "81 - MALUKU" 82 "82 - MALUKU UTARA" 91 "91 - PAPUA BARAT" 94 "94 - PAPUA"
+	label values subnatid1_copy lblsubnatid1
+	decode subnatid1_copy, gen(subnatid1)
+	drop subnatid1_copy
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	tostring kode_kab, replace format(%02.0f)
+	tostring kode_prov, replace
+	gen code_subnatid2 = kode_prov+kode_kab
+	gen subnatid2 = code_subnatid2 + " - " + nama_kab
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen subnatid3 = .
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+	gen subnatidsurvey = "subnatid2"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+================================================================================================*/
+
+{
+
+*<_hsize_>
+	gen byte hsize = b2_r1
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = b4_k8
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = b4_k6
+	recode male 2=0
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	gen byte relationharm = b4_k3
+	recode relationharm (3 4 5 6=3) (7=4) (8=5) (9 10 11=6)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Non-relatives"
+	label values relationharm lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = b4_k3
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = b4_k10
+	recode marital (1=2) (2=1) (3=4) (4=5)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = b5_r4a
+	recode eye_dsablty (3=4)
+	label var eye_dsablty "Disability related to eyesight"
+	la de lbleye_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values eye_dsablty lbleye_dsablty
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = b5_r4b
+	recode hear_dsablty (4=1) (5=2) (6=4)
+	label var hear_dsablty "Disability related to hearing"
+	la de lblhear_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values hear_dsablty lblhear_dsablty
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = b5_r4c
+	recode walk_dsablty (3=4)
+	label var walk_dsablty "Disability related to walking or climbing stairs"
+	la de lblwalk_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values walk_dsablty lblwalk_dsablty
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var conc_dsord "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var slfcre_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = b5_r4f
+	recode comm_dsablty (3=4)
+	label var comm_dsablty "Disability related to communicating"
+	la de lblcomm_dsablty 1 "No" 2 "Yes-some" 3 "Yes-a lot" 4 "Cannot at all"
+	label values comm_dsablty lblcomm_dsablty
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+================================================================================================*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+================================================================================================*/
+
+
+{
+
+*<_ed_mod_age_>
+	gen byte ed_mod_age = 5
+	label var ed_mod_age "Education module application age"
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school = b4_k9
+	recode school (1 3=0) (2=1)
+	replace school = . if age < ed_mod_age & age!=.
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+/*<_educy_note_>
+
+Years of education, or "educy" (and all other related variables were left missing)
+because of the unclear mapping for "Not finished primary school yet".
+
+According to isced-2011 mappings, there are day care centre, playgroup, and
+kindergarten as pre-primary education before 7 years old. Whether to map
+primary unfinished to those options depends on specific assumptions and research
+needs. Therefore, variable "educy" was left missing and so were educat7, educat5,
+and educat4.
+
+In 2019, there is no such category as "No education" nor missing observations. So
+probably the survey grouped "no education" into "not yet completed primary school".
+
+Original code list of variable "b5_r1a" in the dataset:
+1.Not yet completed primary school
+2.Non-formal primary school (Paket A)
+3.Primary School for special needs
+4.Primary school
+5.Non-formal junior high school (Paket B)
+6.Junior high school for special needs
+7.Junior high school
+8.Non-formal senior high school (Paket C)
+9.Senior high school for special needs
+10.Senior high school
+11.Vocational high school(SMK/MAK)
+12.Diploma I/II
+13.Diploma III
+14.Diploma IV/Bachelor
+15.Master
+16.Doctoral
+</_educy_note_>*/
+
+
+*<_educy_>
+	gen byte educy = .
+	replace educy = . if age < ed_mod_age & age!=.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = b5_r1a
+	recode educat7 (1=2) (2/4=3) (5/7=4) (8/11=5) (12/13=6) (14/16=7)
+	replace educat7 = 1 if b4_k9==1
+	replace educat7 = . if age < ed_mod_age & age!=.
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 (4=3) (5=4) (6/7=5)
+	replace educat5 = . if age < ed_mod_age & age!=.
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat5
+	replace educat4 = . if age < ed_mod_age & age!=.
+	recode educat4 (3=2) (4=3) (5=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = b5_r1a
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = b5_r1a
+	recode educat_isced (1=020) (2/4=100) (5/7=244) (8/11=344) (12=454) (13=550) (14=660) (15=760) (16=860)
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*<_educat_isced_v_>
+	gen educat_isced_v="ISCED-2019"
+	label var educat_isced_v "Version of the ISCED used"
+*</_educat_isced_v_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var school literacy educy educat7 educat5 educat4 educat_isced
+foreach v of local ed_var {
+	replace `v' = . if ( age < ed_mod_age & !missing(age) )
+}
+replace educat_isced_v = "" if ( age < ed_mod_age & !missing(age) )
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+================================================================================================*/
+
+
+{
+*<_vocational_>
+	gen vocational = .
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training, lower limit"
+*</_vocational_length_l_>
+
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training, upper limit"
+*</_vocational_length_u_>
+
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+================================================================================================*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 5
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = 1 if b5_r34 != 0
+    replace lstatus = 2 if (b5_r12a==1 | b5_r12b==1) & b5_r18b==1 & missing(lstatus)
+    replace lstatus = 3 if missing(lstatus)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+/*<_potential_lf_note_>
+Note: var "potential_lf" is missing if the respondent is in labor force or unemployed; it only takes value if the respondent is not in labor force. (lstatus==3)
+
+"potential_lf" = 1 if the person is
+1)available but not searching (b5_r18b==1 & b5_r12a==2 & b5_r12b==2 ) or
+2)searching but not immediately available to work b5_r18b==2 & ((b5_r12a==1) | (b5_r12b==1))
+
+. tab b5_r19 b5_r12a, m
+
+           |        b5_r12a
+    b5_r19 |         1          2 |     Total
+-----------+----------------------+----------
+         0 |         0     10,553 |    10,553
+         1 |    32,704    157,482 |   190,186
+         2 |     3,749    578,301 |   582,050
+-----------+----------------------+----------
+     Total |    36,453    746,336 |   782,789
+
+</_potential_lf_note_>*/
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 1 if [ b5_r18b==1 & b5_r12a==2 & b5_r12b==2 ] | [b5_r18b==2 & ((b5_r12a==1) | (b5_r12b==1))]
+	replace potential_lf = 0 if [b5_r18b==1 & (b5_r12a==1 | b5_r12b==1)] | [b5_r18b==2 & b5_r12a==2 & b5_r12b==2]
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+/*<_nlfreason_note_>
+
+The original variable "B5R17A" for 7-day reference period:
+	1  Already had a job, but not starting to work yet
+	2  Having a new business but not starting to work yet
+	3  Desperate: feeling hopeless to get a job
+	4  Already had a job/business
+	5  Having other income sources (pensions, rent, etc.)
+	6  Managing the household
+	7  Attending school/fresh graduate/will continuing school
+	8  Pregnant/being in labor
+	9  Lack of infrastructure (assets, roads, transport, employment service)
+	10 There is no/lack of capital
+	11 Under-age
+	12 Elderly
+	13 Unable to do a job
+	14 Unable to be classified into code 1-13
+
+<_nlfreason_note_>*/
+
+
+*<_nlfreason_>
+	gen byte nlfreason = b5_r17a
+	recode nlfreason (7=1) (6=2) (12=3) (13=4) (1/5 8/11 14=5) (0=.)
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+/*<_unempldur_l_note_>
+
+The original variable "b5_r22b" is the period of seeking job. Therefore, the lower
+and upper bound of unemploymenmt duration are the same. They are in fact the length
+of unemployment period.
+
+<_unempldur_l_note_>*/
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l = b5_r22b
+	replace unempldur_l = . if lstatus != 2
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = b5_r22b
+	replace unempldur_u = . if lstatus!=2
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat = b5_r24a if inrange(b5_r24a, 1, 7)
+	recode empstat (1 2=4) (4/6=1) (7=2) (6=5)
+	replace empstat=.  if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = b5_r34
+	recode ocusec (2 8 9=4) (3/7=2) (0=.)
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+/*<_industry_orig_note_>
+
+Variable "b5_r20_kat" seems to use KBLI 2015 which has one digit and 17 categories in total.
+Note that in the raw dataset variable "b5_r20_kat" does not have labels.
+
+<_industry_orig_note_>*/
+
+
+*<_industry_orig_>
+	gen industry_orig = b5_r20_kat
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+/*<_industrycat_isic_note_>
+
+Because variable "b5_r20_kat" only has one digit and it does not have labels, it
+was not mapped to ISIC.
+
+<_industrycat_isic_note_>*/
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = .
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen byte industrycat10 = b5_r20_kat
+	recode industrycat10 (5=4) (6=5) (7 9=6) (8 10=7) (11 12 13=8) (14=9) (15 16 17=10) (0=.)
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	replace industrycat10 = . if lstatus!=1
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "1 digit industry classification (Broad Economic Activities), primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+/*<_occup_orig_note_>
+
+Variable "b5_r21_kbj" uses KBJI 2014 and it has one digit and 10 categories in total.
+Note that in the raw dataset variable "b5_r21_kbj" does not have labels.
+
+<_occup_orig_note_>*/
+
+
+*<_occup_orig_>
+	gen occup_orig = b5_r21_kbj
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = ""
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_skill = b5_r21_kbj
+	recode occup_skill (1/3=3) (4/8=2) (9=1) (0=.)
+	replace occup_skill = . if lstatus!=1
+	label define lbl_occup_skill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lbl_occup_skill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = b5_r21_kbj
+	replace occup = . if lstatus!=1
+	replace occup = . if  occup==0
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+  	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians and associate professionals" 4 "Clerical support workers" 5 "Service and market sales workers" 6 "Skilled agricultural, forestry and fishery workers" 7 "Craft and related trades workers" 8 "Plant and machine operators, and assemblers" 9 "Elementary occupations"
+	label values occup lbloccup
+*</_occup_>
+
+
+/*<_wage_no_compen_note_>
+
+In the raw dataset, question 28 has 3 parts aksing about working days and monthly salary of 1) self-employed people and 2) employees. Variable "B5_R28B" is for self-employed people whereas "B5_R28C" is for employees.
+
+Each of these two variables devides into "in cash" and "in-kind". For each observation, I calculated the total income by adding up "in cash" and "in-kind" salary.
+
+	count if (b5_r28b1!=0 | b5_r28b2!=0 ) & (b5_r28c1!=0 | b5_r28c2!=0)
+
+3 observations in total answered both "b5_r31B" and "b5_r31C", indicating that they self-employed and employees at the same time. Only one of these observations has the same amount of income (in cash) from the self-employed work and being an employee, which is suspicious. Therefore, I treated this observations as "wrongly" answered the questions and did not add up across "B5_R28B" and  "B5_R28C".
+
+<_wage_no_compen_note_>*/
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	gen wagec1 = b5_r28c1
+	replace wagec1 =0 if (b5_r28b1!=0 | b5_r28b2!=0 ) & (b5_r28c1!=0 | b5_r28c2!=0) & b5_r28b1==b5_r28c1
+	replace wage_no_compen = b5_r28b1+b5_r28b2+wagec1+b5_r28c2
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = 5
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours= b5_r23a
+	replace whours = . if lstatus!=1
+	replace whours = . if b5_r23a == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+/*<_wage_total_note_>
+
+We know the average monthly wage, which is b5_r31. But since we do not know how
+many months each observation works for, we left the annualized total wage missing.
+
+<_wage_total_note_>*/
+
+
+*<_wage_total_>
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+/*<_contract_note_>
+
+We count "Oral agreement" as "having a contract" as well, considering its big magnitude larger than category 1 "employment agreement for unspecified time".
+
+<_contract_note_>*/
+
+
+*<_contract_>
+	gen byte contract = b5_r31
+	recode contract (2/3=1) (4=0) (5 0=.)
+	replace contract = . if lstatus!=1
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = b5_r30a
+	recode healthins (0 3=.) (2=0)
+	replace healthins = . if lstatus!=1
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+/*<_socialsec_note_>
+
+We count both "old age benefit (lump sum)" and "pension benefit (annuity)" as indicators for having social security or not. A given respondent does not have social security if he/she does not have neither.
+
+<_socialsec_note_>*/
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	replace socialsec = 1 if b5_r30d == 4 | b5_r30e == 1
+	replace socialsec = 0 if b5_r30d == 5 & b5_r30d == 2
+	replace socialsec = . if lstatus!=1
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = b5_r32
+	recode union (0 3=.) (2=0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = b5_r24d
+	recode firmsize_l (2=5) (3=20) (4=100) (0=.)
+	replace firmsize_l = . if lstatus!=1
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = b5_r24d
+	recode firmsize_u (1=4) (2=19) (3=99) (0=.)
+	replace firmsize_u = . if lstatus!=1
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = b5_r41a
+	recode empstat_2 (1=4) (2=3) (4/6=1) (7=2) (0=.)
+	replace empstat_2 = . if b5_r37a==2 & b5_r37b == 2
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	la de lblempstat_2 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_2 lblempstat_2
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	la de lblocusec_2 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2 lblocusec_2
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = b5_r38_kat
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2 "1 digit industry classification (Broad Economic Activities), secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = b5_r39_kji
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = b5_r40
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year = . if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year = .
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year = .
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year = .
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 day recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year = industrycat10_year
+	recode industrycat4_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_year "1 digit industry classification (Broad Economic Activities), primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = .
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_>
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 day recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year = industrycat10_2_year
+	recode industrycat4_2_year (1=1) (2 3 4 5 =2) (6 7 8 9=3) (10=4)
+	label var industrycat4_2_year "1 digit industry classification (Broad Economic Activities), secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = .
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but primary & secondary jobs excl. bonuses, etc. 12 month recall)"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	replace njobs = 1 if lstatus ==1 & empstat_2 ==.
+	replace njobs = 2 if lstatus ==1 & empstat_2 !=.
+	replace njobs = 0 if lstatus !=1
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = .
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "`path_output'\\`level_2_harm'_ALL.dta", replace
+
+*</_% SAVE_>


### PR DESCRIPTION
Hi Mario,

This was initialy meant to be a revision to 2014 only. But I took anoher look at other years and found that `industry_orig`, `occup_orig`, `industry_orig_2` and `occup_orig_2` also needed to be recoded as they are supposed to contain the very original values in the raw dataset. In the old versions, I added some conditions to those variables such as `lstatus` must equal 1. 

I have created new `altversion` and new folders for all years, and they are up yto date on the server as well. Let me know if you have questions.  