### PR TITLE
Correct collapse

### DIFF
--- a/Support/D - Q Checks/Single survey checks/Helper_programs_1.5/B2.02_ext_ddB_GLD.do
+++ b/Support/D - Q Checks/Single survey checks/Helper_programs_1.5/B2.02_ext_ddB_GLD.do
@@ -1730,7 +1730,7 @@
 		keep if age >= 15 & !missing(age)
 			
 				 
-		collapse (count) weight, by(countrycode harmonization year empstat) 
+		collapse (sum) weight, by(countrycode harmonization year empstat) 
 
 		egen total_emp = total(weight)
 		gen value = (weight/total_emp)*100


### PR DESCRIPTION
Collapse was counting (value 1 for every non-missing instance) instead of sum weight (adding its value). Corrected.