### PR TITLE
Update AFG LCS coding and CSD notes

### DIFF
--- a/GLD/AFG/AFG_2013_LCS/AFG_2013_LCS_V01_M_V01_A_GLD/Programs/AFG_2013_LCS_V01_M_V01_A_GLD_ALL.do
+++ b/GLD/AFG/AFG_2013_LCS/AFG_2013_LCS_V01_M_V01_A_GLD/Programs/AFG_2013_LCS_V01_M_V01_A_GLD_ALL.do
@@ -75,8 +75,6 @@ local path_in_stata "`server'/`country'/`level_1'/`level_2_mast'/Data/Stata"
 local path_in_other "`server'/`country'/`level_1'/`level_2_mast'/Data/Original"
 local path_output   "`server'/`country'/`level_1'/`level_2_harm'/Data/Harmonized"
 
-local out_file "`level_2_harm'_ALL.dta"
-
 *----------1.3: Database assembly------------------------------*
 
 * All steps necessary to merge datasets (if several) to have all elements needed to produce
@@ -273,6 +271,15 @@ local out_file "`level_2_harm'_ALL.dta"
 {
 
 *<_urban_>
+/* <_urban_note>
+
+	Kuchi households are left missing in `urban`. The survey distinguishes 580
+	Kuchi households as a separate nomadic population group rather than assigning
+	them a fixed urban or rural household location. Their PSU and cluster groups
+	are Kuchi-only in the received raw data, so there are no non-Kuchi households
+	in the same PSU or cluster from which to impute an urban/rural value.
+
+</_urban_note> */
 	gen byte urban=q_1_5
 	recode urban 2=0 3=.
 	label var urban "Location is urban"
@@ -645,8 +652,10 @@ label var ed_mod_age "Education module application age"
 	are treated as no education / no completed grade. Question 10.5 code 7 is
 	Islamic school. This affects 265 cases. Since the Islamic-school track follows
 	its own 0-14 grade ladder, those observations are placed on the GLD ladder by
-	completed grade rather than left as a survey-specific residual category. In the
-	final harmonized file, 63 individuals above `ed_mod_age` remain missing on
+	completed grade rather than left as a survey-specific residual category. This
+	treats Islamic-school respondents consistently with regular-school respondents
+	at the same reported grade. In the final harmonized file, 63 individuals above
+	`ed_mod_age` remain missing on
 	`educat7` because the raw education record is incomplete, usually with both
 	`q_10_5` and `q_10_6` missing despite reported school attendance.
 
@@ -808,6 +817,8 @@ foreach ed_var of local ed_vars {
 	- did farm or livestock work in the last 7 days
 	- did own-account or household business work in the last 7 days
 	- produced durable goods for household use in the last 7 days
+	- was captured by the survey's summary work screen
+	- later confirmed having done any work at all, even for a short time
 	- was temporarily absent from a job but reported work to return to
 
 	Job attachment:
@@ -827,6 +838,12 @@ foreach ed_var of local ed_vars {
 	Non-labour force:
 	- everyone else age 14+
 
+	The detailed work screens q_11_2 to q_11_5 are also included directly in the
+	employment definition so that anyone counted by the survey's own work summary
+	question is covered even if the summary response is incomplete. The follow-up
+	work confirmation q_11_7 is retained to capture people who were not flagged in
+	the earlier detailed work screens but still reported having done some work.
+
 	The labour screening questions do not distinguish farm output for sale from
 	farm output for own consumption, so farm and livestock activity reported in
 	the main work screens is treated as employment under the survey's broader work
@@ -834,7 +851,7 @@ foreach ed_var of local ed_vars {
 
 </_lstatus_note> */
 	gen byte lstatus = .
-	replace lstatus = 1 if inlist(1,q_11_6,q_11_7,q_11_8)
+	replace lstatus = 1 if inlist(1,q_11_2,q_11_3,q_11_4,q_11_5,q_11_6,q_11_7,q_11_8)
 	replace lstatus = 2 if missing(lstatus) & q_11_10 == 1 & q_11_11 == 1
 	replace lstatus = 2 if missing(lstatus) & q_11_10 == 1 & q_11_12 == 8
 	replace lstatus = 3 if missing(lstatus)
@@ -917,6 +934,15 @@ foreach ed_var of local ed_vars {
 
 
 *<_ocusec_>
+/* <_ocusec_note>
+
+	Day labourers are coded as private/non-public because the questionnaire only
+	identifies salaried public-sector workers separately. The raw industry code
+	shows that 52 day labourers, or 0.87 percent of all day labourers, report
+	public administration and defence. This small edge case is noted but not used
+	to treat all day labourers as public or ambiguous.
+
+</_ocusec_note> */
 	gen byte ocusec=q_11_13
 	recode ocusec 3=1 1 2 4/6=2 .a=.
 	replace ocusec=. if lstatus!=1
@@ -949,8 +975,19 @@ foreach ed_var of local ed_vars {
 
 
 *<_industrycat10_>
-	gen byte industrycat10=q_11_19_b
-	replace industrycat10=. if lstatus!=1 | industrycat10==.a
+/* <_industrycat10_note>
+
+	`industrycat10` is derived from the two-digit group retained in
+	`industrycat_isic`. This avoids treating the broad ISIC Rev. 2 community,
+	social, and personal services group as public administration. Only two-digit
+	code 91 is public administration and defence; codes 92 to 96 are other
+	services.
+
+</_industrycat10_note> */
+	gen byte industrycat10 = real(substr(industrycat_isic,1,2)) if industrycat_isic != ""
+	recode industrycat10 (11/13=1) (21/29=2) (31/39=3) (41/42=4) (50=5) ///
+		(61/63=6) (71/72=7) (81/83=8) (91=9) (92/96=10)
+	replace industrycat10=. if lstatus!=1
 	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
 	label define lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Communications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified", replace
 	label values industrycat10 lblindustrycat10
@@ -1155,16 +1192,24 @@ foreach ed_var of local ed_vars {
 
 
 *<_industrycat_isic_2_>
-	gen industrycat_isic_2 = .
-	replace industrycat_isic_2 = . if lstatus != 1
+	gen str4 industrycat_isic_2 = string(q_11_25_a) + "00" if !missing(q_11_25_a)
+	replace industrycat_isic_2 = "" if missing(empstat_2)
 	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
 
 *<_industrycat10_2_>
-	gen byte industrycat10_2=floor(q_11_25/100)
-	replace industrycat10_2=10 if inrange(q_11_25,920,960)
-	replace industrycat10_2=. if missing(empstat_2) | industrycat10_2==.a
+/* <_industrycat10_2_note>
+
+	Secondary-job industry follows the same ISIC Rev. 2 grouping used for the
+	primary job. Code 91 is public administration and defence, while codes 92-96
+	are retained as other services rather than grouped with public administration.
+
+</_industrycat10_2_note> */
+	gen byte industrycat10_2 = real(substr(industrycat_isic_2,1,2)) if industrycat_isic_2 != ""
+	recode industrycat10_2 (11/13=1) (21/29=2) (31/39=3) (41/42=4) (50=5) ///
+		(61/63=6) (71/72=7) (81/83=8) (91=9) (92/96=10)
+	replace industrycat10_2=. if missing(empstat_2)
 	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
 	label values industrycat10_2 lblindustrycat10
 *</_industrycat10_2_>
@@ -1866,6 +1911,6 @@ compress
 
 *<_% SAVE_>
 
-save "`path_output'/`out_file'", replace
+save "`path_output'/`level_2_harm'_ALL.dta", replace
 
 *</_% SAVE_>

--- a/GLD/AFG/AFG_2016_LCS/AFG_2016_LCS_V01_M_V01_A_GLD/Programs/AFG_2016_LCS_V01_M_V01_A_GLD_ALL.do
+++ b/GLD/AFG/AFG_2016_LCS/AFG_2016_LCS_V01_M_V01_A_GLD/Programs/AFG_2016_LCS_V01_M_V01_A_GLD_ALL.do
@@ -75,8 +75,6 @@ local path_in_stata "`server'/`country'/`level_1'/`level_2_mast'/Data/Stata"
 local path_in_other "`server'/`country'/`level_1'/`level_2_mast'/Data/Original"
 local path_output   "`server'/`country'/`level_1'/`level_2_harm'/Data/Harmonized"
 
-local out_file "`level_2_harm'_ALL.dta"
-
 *----------1.3: Database assembly------------------------------*
 
 * All steps necessary to merge datasets (if several) to have all elements needed to produce
@@ -296,6 +294,15 @@ local out_file "`level_2_harm'_ALL.dta"
 {
 
 *<_urban_>
+/* <_urban_note>
+
+	Kuchi households are left missing in `urban`. The survey distinguishes 550
+	Kuchi households as a separate nomadic population group rather than assigning
+	them a fixed urban or rural household location. Their PSU and cluster groups
+	are Kuchi-only in the received raw data, so there are no non-Kuchi households
+	in the same PSU or cluster from which to impute an urban/rural value.
+
+</_urban_note> */
 	gen byte urban = q_1_5
 	recode urban 2=0 3=.
 	label var urban "Location is urban"
@@ -672,6 +679,12 @@ label var ed_mod_age "Education module application age"
 	remain in post-secondary non-university. Cases with `q11_8 == 0` are treated
 	as no completed grade rather than primary incomplete.
 
+	Question 11.7 code 7 is Islamic school. This affects 254 cases. Since the
+	Islamic-school track follows its own 0-14 grade ladder, those observations are
+	placed on the GLD ladder by completed grade rather than left as a
+	survey-specific residual category. This treats Islamic-school respondents
+	consistently with regular-school respondents at the same reported grade.
+
 	</_educat7_note> */
 	gen byte educat7 = 1 if q11_5 == 2
 	replace educat7 = 1 if q11_5 == 1 & q11_8 == 0
@@ -912,6 +925,15 @@ foreach ed_var of local ed_vars {
 
 
 *<_ocusec_>
+/* <_ocusec_note>
+
+	Day labourers are coded as private/non-public because the questionnaire only
+	identifies salaried public-sector workers separately. The raw industry code
+	shows that 40 day labourers, or 0.75 percent of all day labourers, report
+	public administration and defence. This small edge case is noted but not used
+	to treat all day labourers as public or ambiguous.
+
+</_ocusec_note> */
 	gen byte ocusec = .
 	replace ocusec = 1 if q12_13 == 3
 	replace ocusec = 2 if inlist(q12_13,1,2,4,5,6)
@@ -948,7 +970,18 @@ foreach ed_var of local ed_vars {
 
 
 *<_industrycat10_>
-	gen byte industrycat10 = q12_16_b
+/* <_industrycat10_note>
+
+	`industrycat10` is derived from the two-digit group retained in
+	`industrycat_isic`. This avoids treating the broad ISIC Rev. 2 community,
+	social, and personal services group as public administration. Only two-digit
+	code 91 is public administration and defence; codes 92 to 96 are other
+	services.
+
+</_industrycat10_note> */
+	gen byte industrycat10 = real(substr(industrycat_isic,1,2)) if industrycat_isic != ""
+	recode industrycat10 (11/13=1) (21/29=2) (31/39=3) (41/42=4) (50=5) ///
+		(61/63=6) (71/72=7) (81/83=8) (91=9) (92/96=10)
 	replace industrycat10=. if lstatus!=1
 	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
 	label define lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Communications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified", replace
@@ -979,11 +1012,14 @@ foreach ed_var of local ed_vars {
 	The raw occupation variable `q12_17` is a grouped ISCO-08 code stored
 	numerically. It aligns with the first three digits of ISCO-08, so `occup_isco`
 	is coded as a 4-digit string by restoring any leading zero and appending a
-	trailing `0`. If a survey only provides a 1-digit occupation variable, there is
-	no need to separately code `occup_isco` because it adds no detail beyond `occup`.
+	trailing `0`. Raw code 119 affects 1 case and is collapsed to 1100 to retain
+	the manager group without keeping the inconsistent detailed code 1190. If a
+	survey only provides a 1-digit occupation variable, there is no need to
+	separately code `occup_isco` because it adds no detail beyond `occup`.
 
 </_occup_isco_note> */
 	gen str4 occup_isco = string(q12_17, "%03.0f") + "0" if !missing(q12_17)
+	replace occup_isco = "1100" if q12_17 == 119
 	replace occup_isco = "" if lstatus != 1
 	label var occup_isco "ISCO code of primary job 7 day recall"
 *</_occup_isco_>
@@ -1151,8 +1187,7 @@ foreach ed_var of local ed_vars {
 
 
 *<_industrycat_isic_2_>
-	gen industrycat_isic_2 = .
-	replace industrycat_isic_2 = . if lstatus != 1
+	gen str4 industrycat_isic_2 = ""
 	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
 *</_industrycat_isic_2_>
 
@@ -1860,6 +1895,6 @@ compress
 
 *<_% SAVE_>
 
-save "`path_output'/`out_file'", replace
+save "`path_output'/`level_2_harm'_ALL.dta", replace
 
 *</_% SAVE_>

--- a/Support/B - Country Survey Details/AFG/LCS/1. Introduction to AFG LCS.md
+++ b/Support/B - Country Survey Details/AFG/LCS/1. Introduction to AFG LCS.md
@@ -42,11 +42,15 @@ The survey design supports national and provincial estimates. In the official la
 
 ### Labour status and job attachment
 
-The GLD codes labour status from the concept used in the survey questionnaire. In both the 2013-14 and 2016-17 rounds, the questionnaire uses a direct temporary-absence question as the operative job-attachment test. Respondents who report that they usually work but were only temporarily absent are routed into the main-job module, while those who do not report temporary absence are routed to the availability and search branch. For this reason, temporary absence is treated as attachment to a job in the GLD harmonization in both rounds.
+In both the 2013-14 and 2016-17 rounds, respondents who report that they usually work but were temporarily absent are routed into the main-job module. The GLD therefore treats temporary absence as employment by default in these rounds, following the questionnaire flow. This affects a small share of the labour-status universe: 893 respondents in 2013-14 and 491 respondents in 2016-17. Weighted, these temporarily absent respondents represent 1.24 percent of the labour-status universe in 2013-14 and 0.51 percent in 2016-17.
 
-In the 2016-17 round, unemployment is likewise built from the survey's own search and availability questions, and the survey also identifies respondents who have already found a future job. The GLD does not impose an external job-attachment rule beyond the routing observed in the questionnaire.
+This is a survey-specific operational choice. The [ILO 19th ICLS guidance](https://www.ilo.org/sites/default/files/wcmsp5/groups/public/%40dgreports/%40stat/documents/publication/wcms_220535.pdf) treats temporary absence as an employment concept only when there is continued job attachment and the absence is expected to be short; the guidance notes that duration thresholds are generally not longer than three months. Some survey implementations also test return to the same job, reason for absence, and remuneration during absence. The AFG LCS questionnaire does not collect a full duration-and-remuneration test at this point in the labour module, so the GLD follows the routing in the questionnaire rather than imposing an additional external rule.
+
+In the 2016-17 round, unemployment is likewise built from the survey's own search and availability questions, and the survey also identifies respondents who have already found a future job.
 
 ### Education: schooling track and Islamic school mapping
+
+Islamic schooling could follow a different education system from regular schooling. At the same time, Afghanistan's education framework treats Islamic Education as one of the subsectors of the education system. The [UNESCO Institute for Lifelong Learning](https://www.uil.unesco.org/en/articles/recognition-validation-and-accreditation-afghanistan) notes that Afghanistan's qualifications framework covers TVET, General Education, Islamic Education, Basic Education, Higher Education, Literacy, and Non-formal Education, and that Islamic Education currently goes up to grade 14. For this reason, the GLD treats Islamic-school grades as broadly comparable to regular-school grades for the purpose of assigning broad `educat7` categories, rather than excluding Islamic-school respondents from the standard education ladder.
 
 In the 2013-14 round, the questionnaire records education using `q_10_5` for the schooling track and `q_10_6` for the highest completed grade within that track. In practice, the GLD codes `educat7` mainly from `q_10_6`, together with `q_10_4` for those who never attended school. The role of `q_10_5` is to interpret what the ranges of values in `q_10_6` correspond to in the questionnaire.
 
@@ -74,30 +78,26 @@ Using those ranges, the GLD maps `educat7` in the 2013-14 round into the followi
 | `6` Higher than secondary but not university | `q_10_6 = 13-14`, including Islamic school |
 | `7` University incomplete or complete | `q_10_6 = 15-19` |
 
-This matters most for Islamic school (`q_10_5 = 7`). Rather than leaving these observations as a separate residual category, the GLD places them into the standard `educat7` ladder according to the completed grade reported in `q_10_6`. This affects 265 observations in the 2013-14 round.
+This matters most for Islamic school, which is code `7` in the education-track variable in both rounds. Rather than leaving these observations as a separate residual category, the GLD places them into the standard `educat7` ladder according to the completed grade reported in the questionnaire. This affects 265 observations in the 2013-14 round and 254 observations in the 2016-17 round.
 
 ### Industry classification
 
-The industry variables in the AFG LCS align most closely with ISIC Revision 2 at the first two digits. The exact source classification used in the survey materials could not be identified from the available documentation. In the GLD harmonization, the survey coding is therefore mapped conservatively to ISIC Rev. 2 at the 2-digit level.
+The industry variables in the AFG LCS align most closely with ISIC Revision 2 at the first two digits. The exact source classification used in the survey materials could not be identified from the available documentation. In the GLD harmonization, the survey coding is therefore mapped conservatively to ISIC Rev. 2 at the 2-digit level, stored as `XX00`.
 
 | Year(s) | Classification in survey | ISIC revision mapped to | Level of compatibility |
 |---------|---------------------------|-------------------------|------------------------|
 | 2013 | Unknown | ISIC Revision 2 | 2 digits |
 | 2016 | Unknown | ISIC Revision 2 | 2 digits |
 
-Detailed industry comparisons should be interpreted at the 2-digit grouped level rather than as exact detailed ISIC codes.
+Detailed industry comparisons should be interpreted at the 2-digit grouped level rather than as exact detailed ISIC codes. This is also important for broad industry groups: two-digit code `91` is public administration and defence, while codes `92-96` are treated as other services.
 
 ### Occupation classification
 
-The occupation variables in the AFG LCS align most closely with ISCO-08 at the first two digits. The exact source classification used in the survey materials could not be identified from the available documentation. In the GLD harmonization, the survey coding is therefore mapped conservatively to ISCO-08 at the 2-digit level.
+The occupation variables in the AFG LCS align most closely with grouped ISCO-08 codes at the first three digits. The exact source classification used in the survey materials could not be identified from the available documentation. In the GLD harmonization, the survey coding is therefore mapped conservatively to ISCO-08 as a grouped 3-digit code, stored as `XXX0`.
 
 | Year(s) | Classification in survey | ISCO revision mapped to | Level of compatibility |
 |---------|---------------------------|-------------------------|------------------------|
-| 2013 | Unknown | ISCO-08 | 2 digits |
-| 2016 | Unknown | ISCO-08 | 2 digits |
+| 2013 | Unknown | ISCO-08 | grouped 3 digits |
+| 2016 | Unknown | ISCO-08 | grouped 3 digits |
 
-Detailed occupation comparisons should be interpreted at the 2-digit grouped level rather than as exact detailed ISCO codes.
-
-### Wages
-
-The 2016-17 labour questionnaire does not collect an individual wage amount for the respondent's main job. It records employment status, industry, occupation, hours, and related labour characteristics, while household income is captured elsewhere at the household level. For this reason, the GLD leaves `wage_no_compen` and `unitwage` missing for the 2016-17 round rather than forcing a person-level wage measure that the survey does not support.
+Detailed occupation comparisons should be interpreted at the grouped 3-digit level rather than as exact detailed ISCO codes.

--- a/Support/B - Country Survey Details/AFG/LCS/1. Introduction to AFG LCS.md
+++ b/Support/B - Country Survey Details/AFG/LCS/1. Introduction to AFG LCS.md
@@ -4,7 +4,7 @@
 - [What does the AFG LCS cover?](#what-does-the-afg-lcs-cover)
 - [Where can the data be found?](#where-can-the-data-be-found)
 - [What is the sampling procedure?](#what-is-the-sampling-procedure)
-- [What is the significance level?](#what-is-the-significance-level)
+- [What is the geographic significance level?](#what-is-the-geographic-significance-level)
 - [Other noteworthy aspects](#other-noteworthy-aspects)
 
 ## What is the AFG LCS?
@@ -34,9 +34,11 @@ The AFG LCS rounds covered in the GLD use a stratified cluster sampling design w
 
 The 2013-14 and 2016-17 rounds follow the same overall design. One implementation difference is that in 2013-14, some sampled rural enumeration areas that contained more than one village effectively introduced an additional village-selection step before household selection.
 
-## What is the significance level?
+## What is the geographic significance level?
 
-The survey design supports national and provincial estimates. In the official labour reporting, labour indicators are presented most consistently by residence category, especially urban, rural, and Kuchi, rather than by province.
+While the survey design supports national and provincial estimates, in the official labour reporting, labour indicators are presented most consistently by residence category — urban, rural, and Kuchi — rather than by province. Kuchi are Afghan nomadic pastoralists (see [Wikipedia](https://en.wikipedia.org/wiki/Kochis) for more detail). Given that official reporting relies solely on this national-level, three-category breakdown, the survey is treated as significant at the national level across these three groups.
+
+For urban and rural households, significance extends to the urban/rural distinction in the standard way. For Kuchi households, the `urban` variable is missing. Rather than recording the location of Kuchi households at the time of interview, the survey instrument assigns them a fixed third residence category. Since Kuchi PSUs and clusters contain no non-Kuchi households, no within-PSU information exists from which to impute an urban or rural value, and the assignment cannot be corrected in processing.
 
 ## Other noteworthy aspects
 
@@ -50,7 +52,7 @@ In the 2016-17 round, unemployment is likewise built from the survey's own searc
 
 ### Education: schooling track and Islamic school mapping
 
-Islamic schooling could follow a different education system from regular schooling. At the same time, Afghanistan's education framework treats Islamic Education as one of the subsectors of the education system. The [UNESCO Institute for Lifelong Learning](https://www.uil.unesco.org/en/articles/recognition-validation-and-accreditation-afghanistan) notes that Afghanistan's qualifications framework covers TVET, General Education, Islamic Education, Basic Education, Higher Education, Literacy, and Non-formal Education, and that Islamic Education currently goes up to grade 14. For this reason, the GLD treats Islamic-school grades as broadly comparable to regular-school grades for the purpose of assigning broad `educat7` categories, rather than excluding Islamic-school respondents from the standard education ladder.
+Islamic schooling could follow a different education system from non-religious schooling. At the same time, Afghanistan's education framework treats Islamic Education as one of the subsectors of the education system. The [UNESCO Institute for Lifelong Learning](https://www.uil.unesco.org/en/articles/recognition-validation-and-accreditation-afghanistan) notes that Afghanistan's qualifications framework covers TVET, General Education, Islamic Education, Basic Education, Higher Education, Literacy, and Non-formal Education, and that Islamic Education currently goes up to grade 14. For this reason, the GLD treats Islamic-school grades as broadly comparable to regular-school grades for the purpose of assigning broad `educat7` categories, rather than excluding Islamic-school respondents from the standard education ladder.
 
 In the 2013-14 round, the questionnaire records education using `q_10_5` for the schooling track and `q_10_6` for the highest completed grade within that track. In practice, the GLD codes `educat7` mainly from `q_10_6`, together with `q_10_4` for those who never attended school. The role of `q_10_5` is to interpret what the ranges of values in `q_10_6` correspond to in the questionnaire.
 

--- a/Support/B - Country Survey Details/AFG/LCS/Utilities/AFG_2013_GLD_vs_SARMD_coding_issues.md
+++ b/Support/B - Country Survey Details/AFG/LCS/Utilities/AFG_2013_GLD_vs_SARMD_coding_issues.md
@@ -56,6 +56,8 @@ replace lstatus=3 if q_11_11==2
 
 Some employed people are left without a sector classification in the SARMD version. In the questionnaire, `q_11_13==3` is explicitly “salaried worker, public sector.” The other employed categories `q_11_13==1`, `2`, `4`, `5`, and `6` are not public-sector salaried workers. The GLD therefore treats them as non-public. That is a practical assumption rather than a literal statement that every self-employed or unpaid family worker is private in all cases. In principle, someone could be self-employed while working mainly for government clients, but that is likely to be rare. Even in settings where government contracting is common, those workers are still usually private rather than public employees. The survey does not provide a separate status code for that situation. SARMD only codes `q_11_13==3` as public and `q_11_13==2` as private, so some valid workers are left uncoded instead of being assigned to the non-public side.
 
+Day labourers are the main category where this assumption may hide a small public-sector edge case. In the raw industry coding, two-digit code `91` is public administration and defence, while the one-digit code `9` is the broader community, social, and personal services group. Among day labourers, only 52 cases in 2013, or 0.87 percent of day labourers, are in two-digit industry `91`. The comparable 2016 figure is 40 cases, or 0.75 percent of day labourers. This is worth noting, but it is too small to justify treating all day labourers as public or ambiguous.
+
 ### Raw coding details
 
 | Variable | Raw code | Raw meaning | GLD treatment | SARMD treatment |

--- a/Support/B - Country Survey Details/AFG/LCS/Utilities/AFG_2016_GLD_vs_SARMD_coding_issues.md
+++ b/Support/B - Country Survey Details/AFG/LCS/Utilities/AFG_2016_GLD_vs_SARMD_coding_issues.md
@@ -8,7 +8,7 @@ Files reviewed:
 
 ## Labor status
 
-Labor status should not be taken directly from the given `activity_status` variable in this survey. The main reason is that it does not line up cleanly with the survey flow. The GLD rebuilds labor status directly from the labor questions. SARMD collapses the given `activity_status` variable into employed, unemployed, and non-LF. Those two approaches agree on the narrow unemployment core, but they differ in some important places. Most notably, the given `activity_status` variable treats some people as unemployed even though they reported current-week work or temporary absence from work. It also treats some apprentices, temporarily laid-off people, and similar cases as employed even though they do not fall into the GLD employment branch.
+The given `activity_status` variable should not replace the questionnaire-based GLD labor-status coding in this survey. The main reason is that it does not line up cleanly with the survey flow. The GLD rebuilds labor status directly from the labor questions. SARMD collapses the given `activity_status` variable into employed, unemployed, and non-LF. Those two approaches agree on the narrow unemployment core, but they differ in some important places. Most notably, the given `activity_status` variable treats some people as unemployed even though they reported current-week work or temporary absence from work. It also treats some apprentices, temporarily laid-off people, and similar cases as employed even though they do not fall into the GLD employment branch.
 
 The current-week work questions ask whether the person:
 - worked for a business, organization, or person outside the household
@@ -107,6 +107,27 @@ SARMD:
 
 ```stata
 recode activity_status (2=1) (3=2) (4=3), gen(lstatus)
+```
+
+## Sector of activity (`ocusec`)
+
+The GLD and SARMD use the same broad `ocusec` treatment in 2016: salaried public-sector workers are public, while day labourers, private salaried workers, self-employed workers, employers, and unpaid family workers are treated as non-public. The possible concern is day labourers. In the raw industry coding, two-digit code `91` is public administration and defence, while the one-digit code `9` is the broader community, social, and personal services group. Only 40 day labourers in 2016, or 0.75 percent of all day labourers, are in two-digit industry `91`. The comparable 2013 figure is 52 cases, or 0.87 percent of day labourers. This is worth noting, but it is too small to justify treating all day labourers as public or ambiguous.
+
+### Code snippets
+
+GLD:
+
+```stata
+gen byte ocusec = .
+replace ocusec = 1 if q12_13 == 3
+replace ocusec = 2 if inlist(q12_13,1,2,4,5,6)
+replace ocusec=. if lstatus!=1
+```
+
+SARMD:
+
+```stata
+recode q12_13 (1 2 4 5 6=2) (3=1), gen(ocusec)
 ```
 
 ## Reason out of labor force


### PR DESCRIPTION
## Summary

This PR updates the AFG 2013-14 and 2016-17 LCS harmonization and Country Survey Details notes.

Changes include:
- updates to labour-status documentation and questionnaire-flow treatment for temporary absence
- corrected AFG LCS industry coding so `industrycat10` is derived from the retained two-digit ISIC Rev. 2 group
- secondary-job industry alignment for 2013 using the same ISIC Rev. 2 grouping logic
- notes on Kuchi urban/rural treatment, Islamic schooling, and day-labourer sector assumptions
- revised AFG LCS CSD wording for labour status, Islamic schooling, industry, and occupation classification

## Validation

- Ran the final repo-synced 2013 and 2016 do-files locally in Stata MP 19 using temporary local path copies.
- Confirmed the committed do-files keep the WBG server path block and do not use local Downloads paths.
- Checked weighted 2013-2016 movement in `lstatus`, `subnatid1`, `empstat`, `industrycat10`, `ocusec`, and `occup`.
- Verified no invalid primary or secondary `industrycat10` mappings after the industry update.
