### PR TITLE
Add GLD classification helper checks

### DIFF
--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/README.md
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/README.md
@@ -2,18 +2,46 @@
 
 ## What is the issue?
 
-GLD harmonization often needs to identify whether raw industry and occupation codes align with an ISIC or ISCO revision before assigning `industrycat_isic` or `occup_isco`.
+GLD harmonization often needs to identify which ISIC or ISCO revision a raw industry or occupation variable most likely follows before assigning `industrycat_isic` or `occup_isco`.
 
-These Stata helper commands compare the unique codes in the loaded data with the GLD helper lists used in the single-survey quality checks.
+The main difficulty is that the raw data may contain only numeric codes, while the questionnaire or codebook may not clearly state the classification revision. In those cases, a harmonizer needs a quick way to compare the observed code list against the available GLD reference lists.
 
 ## How is it addressed?
 
-The folder includes two commands:
+This folder includes two Stata commands:
 
-- `gld_isic_check`: checks industry codes against available ISIC helper-list versions.
-- `gld_isco_check`: checks occupation codes against available ISCO helper-list versions.
+- `gld_isic_check`: compares observed industry codes against available ISIC helper-list versions.
+- `gld_isco_check`: compares observed occupation codes against available ISCO helper-list versions.
 
-Each command reports how many unique codes match each reference version and the share of unique codes matched. With the `show` option, the command lists codes in the data that do not match a given reference version.
+Each command collapses the loaded data to the unique non-missing codes in the selected variable, then compares those unique codes with every available reference version. The command reports the number and share of unique observed codes that match each version. With the `show` option, it lists the observed codes that do not match each version.
+
+## How is this different from the ISIC ISCO universe check?
+
+This tool is related to, but different from, the existing [`ISIC ISCO universe check`](../ISIC%20ISCO%20universe%20check/README.md).
+
+Use the existing `int_classif_universe` command when:
+
+- the data are already harmonized,
+- the dataset already has `isic_version` or `isco_version`,
+- you want to check one known classification universe, and
+- you want a dataset listing out-of-universe codes with the number of records affected.
+
+Use `gld_isic_check` or `gld_isco_check` when:
+
+- you are still deciding which ISIC or ISCO revision the source codes resemble,
+- the source is a raw or candidate harmonization variable,
+- you want to compare the same observed code list against all available reference versions, and
+- you want a quick unique-code match diagnostic before finalizing the harmonization rule.
+
+In short, `int_classif_universe` is a post-harmonization validation tool for a known version. These commands are pre-harmonization or review diagnostics for identifying which version best fits the observed codes.
+
+These commands also count unique observed codes, not records. A code that appears once and a code that appears many times have the same weight in the match percentage. If the concern is the number of affected observations after a version has been selected, use `int_classif_universe`.
+
+## How is this different from the Global collection R check?
+
+The `Global collection/isic_isco_checks.R` script checks the share of non-missing `industrycat_isic` and `occup_isco` values by year in a prepared data object. It is a coverage check. It does not compare observed codes to ISIC or ISCO reference lists.
+
+The commands in this folder check whether the observed code values themselves match the possible values in ISIC or ISCO reference versions.
 
 ## How to install the functions?
 
@@ -47,3 +75,9 @@ To list unmatched codes for each version:
 gld_isic_check, industry(raw_industry_variable) show
 gld_isco_check, occupation(raw_occupation_variable) show
 ```
+
+## How to interpret the output?
+
+The output is a screening diagnostic. A 100 percent match with a version is strong evidence that all observed codes are valid in that reference list. A lower match percentage means some observed codes are not in that version.
+
+This does not prove that the survey officially used the version with the highest match. The final decision should still consider the questionnaire, codebook, labels, official survey documentation, and any country-specific classification notes.

--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/README.md
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/README.md
@@ -4,7 +4,9 @@
 
 GLD harmonization often needs to identify which ISIC or ISCO revision a raw industry or occupation variable most likely follows before assigning `industrycat_isic` or `occup_isco`.
 
-The main difficulty is that the raw data may contain only numeric codes, while the questionnaire or codebook may not clearly state the classification revision. In those cases, a harmonizer needs a quick way to compare the observed code list against the available GLD reference lists.
+The main difficulty is that the questionnaire or codebook may not clearly state the classification revision. In those cases, a harmonizer needs a quick way to compare the observed code list against the available GLD reference lists.
+
+The industry or occupation variable must be stored as a string variable. This matters because classification codes often have meaningful leading zeroes. If the source variable is numeric, create a string copy before running the check.
 
 ## How is it addressed?
 
@@ -14,6 +16,8 @@ This folder includes two Stata commands:
 - `gld_isco_check`: compares observed occupation codes against available ISCO helper-list versions.
 
 Each command collapses the loaded data to the unique non-missing codes in the selected variable, then compares those unique codes with every available reference version. The command reports the number and share of unique observed codes that match each version. With the `show` option, it lists the observed codes that do not match each version.
+
+The basic use case is simple. If you have an industry variable and do not know the ISIC version, run `gld_isic_check` on that variable. The command shows how many unique industry codes match each ISIC version. The version with the strongest match is the version the industry code is most likely to follow. The same logic applies to occupation codes with `gld_isco_check`.
 
 ## How is this different from the ISIC ISCO universe check?
 
@@ -69,6 +73,13 @@ gld_isic_check, industry(raw_industry_variable)
 gld_isco_check, occupation(raw_occupation_variable)
 ```
 
+The selected variable must be string. If a numeric code has to be converted first, create a string copy with the correct width for the classification:
+
+```stata
+tostring raw_industry_variable, generate(raw_industry_string) format(%04.0f)
+gld_isic_check, industry(raw_industry_string)
+```
+
 To list unmatched codes for each version:
 
 ```stata
@@ -79,5 +90,7 @@ gld_isco_check, occupation(raw_occupation_variable) show
 ## How to interpret the output?
 
 The output is a screening diagnostic. A 100 percent match with a version is strong evidence that all observed codes are valid in that reference list. A lower match percentage means some observed codes are not in that version.
+
+The `show` option is useful when one version almost fully matches. It lists the observed codes that are mismatched for each reference version. If all substantive codes match one version and the only mismatches are values such as `9999`, `0000`, or other survey-specific error or missing-value codes, that is evidence that the selected version is likely correct and those unmatched values should be reviewed as possible missing codes before harmonization.
 
 This does not prove that the survey officially used the version with the highest match. The final decision should still consider the questionnaire, codebook, labels, official survey documentation, and any country-specific classification notes.

--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/README.md
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/README.md
@@ -1,0 +1,49 @@
+# GLD Classification Code Checks
+
+## What is the issue?
+
+GLD harmonization often needs to identify whether raw industry and occupation codes align with an ISIC or ISCO revision before assigning `industrycat_isic` or `occup_isco`.
+
+These Stata helper commands compare the unique codes in the loaded data with the GLD helper lists used in the single-survey quality checks.
+
+## How is it addressed?
+
+The folder includes two commands:
+
+- `gld_isic_check`: checks industry codes against available ISIC helper-list versions.
+- `gld_isco_check`: checks occupation codes against available ISCO helper-list versions.
+
+Each command reports how many unique codes match each reference version and the share of unique codes matched. With the `show` option, the command lists codes in the data that do not match a given reference version.
+
+## How to install the functions?
+
+The functions can be installed directly from the internet by typing the following into the Stata console:
+
+```stata
+net install gld_classification_code_checks, replace from("https://raw.githubusercontent.com/worldbank/gld/main/Support/Z%20-%20GLD%20Ecosystem%20Tools/GLD%20Classification%20Code%20Checks")
+```
+
+Keep the `replace` option so Stata can overwrite the code if the functions are updated.
+
+## How to run the code?
+
+With a dataset loaded, run:
+
+```stata
+gld_isic_check
+gld_isco_check
+```
+
+By default, `gld_isic_check` uses `industrycat_isic` and `gld_isco_check` uses `occup_isco`. To use another variable:
+
+```stata
+gld_isic_check, industry(raw_industry_variable)
+gld_isco_check, occupation(raw_occupation_variable)
+```
+
+To list unmatched codes for each version:
+
+```stata
+gld_isic_check, industry(raw_industry_variable) show
+gld_isco_check, occupation(raw_occupation_variable) show
+```

--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/gld_classification_code_checks.pkg
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/gld_classification_code_checks.pkg
@@ -1,0 +1,8 @@
+v 1
+d GLD Classification Code Checks: Stata helpers to compare industry and occupation codes against GLD ISIC and ISCO helper lists.
+d Creator: World Bank Jobs Group
+d Author: GLD Team
+d For any questions, please contact: gld@worldbankgroup.org
+d Distribution-Date: 2026-07-02
+f gld_isic_check.ado
+f gld_isco_check.ado

--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/gld_isco_check.ado
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/gld_isco_check.ado
@@ -1,0 +1,53 @@
+capture program drop gld_isco_check
+
+program define gld_isco_check
+
+    syntax [, occupation(varname) show]
+
+    tempvar count
+    qui gen `count' = 1
+
+    * Default occupation variable
+    if "`occupation'" == "" local occupation occup_isco
+
+    preserve
+        * Collapse to unique occupation codes in the current data
+        qui collapse (sum) `count', by(`occupation')
+        qui drop if missing(`occupation')
+        local total_occupations = _N
+
+        tempfile startingdata
+        qui save `startingdata'
+    restore
+
+    preserve
+        * Load ISCO helper list from GLD repo
+        qui import delimited "https://raw.githubusercontent.com/worldbank/gld/main/Support/D%20-%20Q%20Checks/Single%20survey%20checks/Helper_programs_1.5/isco_codes.txt", delimiter(comma) varnames(1) stringcols(_all) clear
+        qui levelsof version, local(ver)
+
+        tempfile iscolist
+        qui save `iscolist'
+    restore
+
+    preserve
+        foreach v of local ver {
+            use `iscolist', clear
+            qui keep if version == "`v'"
+            rename code `occupation'
+
+            qui merge 1:1 `occupation' using `startingdata'
+            qui count if _merge == 3
+            local matches = r(N)
+
+            local percent_match = (100 * `matches') / `total_occupations'
+
+            di "Version `v' matches: `matches' ==> " %8.2f `percent_match' "% of total occupation codes in data"
+
+            if "`show'" != "" & `percent_match' != 100 {
+                di as error "These are the codes not in `v'"
+                list `occupation' if _merge == 2
+            }
+        }
+    restore
+
+end

--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/gld_isic_check.ado
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/gld_isic_check.ado
@@ -1,0 +1,53 @@
+capture program drop gld_isic_check
+
+program define gld_isic_check
+
+    syntax [, industry(varname) show]
+
+    tempvar count
+    qui gen `count' = 1
+
+    * Default industry variable
+    if "`industry'" == "" local industry industrycat_isic
+
+    preserve
+        * Collapse to unique industry codes in the current data
+        qui collapse (sum) `count', by(`industry')
+        qui drop if missing(`industry')
+        local total_industries = _N
+
+        tempfile startingdata
+        qui save `startingdata'
+    restore
+
+    preserve
+        * Load ISIC helper list from GLD repo
+        qui import delimited "https://raw.githubusercontent.com/worldbank/gld/main/Support/D%20-%20Q%20Checks/Single%20survey%20checks/Helper_programs_1.5/isic_codes.txt", delimiter(comma) varnames(1) stringcols(_all) clear
+        qui levelsof version, local(ver)
+
+        tempfile isiclist
+        qui save `isiclist'
+    restore
+
+    preserve
+        foreach v of local ver {
+            use `isiclist', clear
+            qui keep if version == "`v'"
+            rename code `industry'
+
+            qui merge 1:1 `industry' using `startingdata'
+            qui count if _merge == 3
+            local matches = r(N)
+
+            local percent_match = (100 * `matches') / `total_industries'
+
+            di "Version `v' matches: `matches' ==> " %8.2f `percent_match' "% of total industry codes in data"
+
+            if "`show'" != "" & `percent_match' != 100 {
+                di as error "These are the codes not in `v'"
+                list `industry' if _merge == 2
+            }
+        }
+    restore
+
+end

--- a/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/stata.toc
+++ b/Support/Z - GLD Ecosystem Tools/GLD Classification Code Checks/stata.toc
@@ -1,0 +1,5 @@
+v 1
+d GLD Classification Code Checks: Stata helpers to compare industry and occupation codes against GLD ISIC and ISCO helper lists.
+d Creator: World Bank Jobs Group
+d Author: GLD Team
+d Distribution-Date: 2026-07-02


### PR DESCRIPTION
## Summary
- Adds a new `GLD Classification Code Checks` folder under `Support/Z - GLD Ecosystem Tools`.
- Adds `gld_isic_check.ado` and `gld_isco_check.ado` for comparing observed unique industry and occupation string codes against available ISIC and ISCO helper-list versions.
- Adds Stata package metadata and a README with installation, usage, interpretation, and how this differs from the existing `ISIC ISCO universe check` and `Global collection/isic_isco_checks.R`.

## How to use the helper
- The industry or occupation variable must be stored as a string variable.
- Run `gld_isic_check, industry(varname)` or `gld_isco_check, occupation(varname)` to see how many unique observed codes match each classification version.
- The version with the strongest match is the likely candidate version.
- Use the `show` option to list mismatched observed codes by version. If only values such as `9999` or `0000` fail to match while the substantive codes match, those values should be reviewed as possible missing or error codes before harmonization.

## Validation
- Confirmed the two `.ado` files match the Codex skill sources exactly.
- Reviewed the existing ecosystem tools and followed the folder plus README plus package metadata pattern.
- Compared against the existing `ISIC ISCO universe check` README and command before revising the new README.
- Ran `git diff --check origin/main..HEAD`.

## Notes
- This branch is based on current `origin/main`.
- The earlier experimental `test-here` branch is not used for this PR.
